### PR TITLE
Modernization, memory optimization, safe parallelization, and bug fixes

### DIFF
--- a/PDIndexer/DataConverter/EDXControl.Designer.cs
+++ b/PDIndexer/DataConverter/EDXControl.Designer.cs
@@ -116,8 +116,8 @@ namespace PDIndexer
             // 
             // EDXControl
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 17F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Controls.Add(this.numericBoxEGC2);
             this.Controls.Add(this.numericBoxEGC1);

--- a/PDIndexer/DataSet.cs
+++ b/PDIndexer/DataSet.cs
@@ -36,7 +36,7 @@ public partial class DataSet
 
             r.PlaneObject = p;
 
-            r.HKL = p.strHKL == null ? "" : p.strHKL;
+            r.HKL = p.strHKL ?? ""; //260712Cl null合体演算子
             r.Check = p.IsFittingChecked;
             r.CalcX = p.XCalc;
             r.X = p.peakFunction.X;
@@ -159,18 +159,10 @@ public partial class DataSet
         {
             if (srcIndex < this.Rows.Count && destIndex < this.Rows.Count)
             {
-                bool check = (bool)this.Rows[srcIndex][0];
-                this.Rows[srcIndex][0] = this.Rows[destIndex][0];
-                this.Rows[destIndex][0] = check;
-
-
-                DiffractionProfile2 c = (DiffractionProfile2)this.Rows[srcIndex][1];
-                this.Rows[srcIndex][1] = this.Rows[destIndex][1];
-                this.Rows[destIndex][1] = c;
-
-                Bitmap bmp = (Bitmap)this.Rows[srcIndex][2];
-                this.Rows[srcIndex][2] = this.Rows[destIndex][2];
-                this.Rows[destIndex][2] = bmp;
+                // 260712Cl 記法近代化: 一時変数3連スワップ → タプル分解スワップ (右辺先行評価で意味論同一)
+                (this.Rows[srcIndex][0], this.Rows[destIndex][0]) = (this.Rows[destIndex][0], this.Rows[srcIndex][0]);
+                (this.Rows[srcIndex][1], this.Rows[destIndex][1]) = (this.Rows[destIndex][1], this.Rows[srcIndex][1]);
+                (this.Rows[srcIndex][2], this.Rows[destIndex][2]) = (this.Rows[destIndex][2], this.Rows[srcIndex][2]);
 
             }
         }
@@ -251,7 +243,8 @@ public partial class DataSet
         {
             if (checkedIndex >= CheckedItems.Count || checkedIndex < 0) return -1;
             int n = -1;
-            for (int i = 0; i < Items.Count; i++)
+            int count = Items.Count; //260712Cl Items.Count を1回だけ評価 (旧: ループ条件で毎回 List 全生成→O(n²))。Items 依存の挙動 (不正行での空リストfallback) は維持
+            for (int i = 0; i < count; i++)
                 if (GetItemChecked(i))
                 {
                     n++;
@@ -316,18 +309,10 @@ public partial class DataSet
         {
             if (srcIndex < this.Rows.Count && destIndex < this.Rows.Count)
             {
-                bool check = (bool)this.Rows[srcIndex][0];
-                this.Rows[srcIndex][0] = this.Rows[destIndex][0];
-                this.Rows[destIndex][0] = check;
-
-
-                Crystal c = (Crystal)this.Rows[srcIndex][1];
-                this.Rows[srcIndex][1] = this.Rows[destIndex][1];
-                this.Rows[destIndex][1] = c;
-
-                Bitmap bmp = (Bitmap)this.Rows[srcIndex][2];
-                this.Rows[srcIndex][2] = this.Rows[destIndex][2];
-                this.Rows[destIndex][2] = bmp;
+                // 260712Cl 記法近代化: 一時変数3連スワップ → タプル分解スワップ (右辺先行評価で意味論同一)
+                (this.Rows[srcIndex][0], this.Rows[destIndex][0]) = (this.Rows[destIndex][0], this.Rows[srcIndex][0]);
+                (this.Rows[srcIndex][1], this.Rows[destIndex][1]) = (this.Rows[destIndex][1], this.Rows[srcIndex][1]);
+                (this.Rows[srcIndex][2], this.Rows[destIndex][2]) = (this.Rows[destIndex][2], this.Rows[srcIndex][2]);
 
             }
         }
@@ -392,7 +377,8 @@ public partial class DataSet
         {
             if (checkedIndex >= CheckedItems.Count || checkedIndex < 0) return -1;
             int n = -1;
-            for (int i = 0; i < Items.Count; i++)
+            int count = Items.Count; //260712Cl Items.Count を1回だけ評価 (旧: ループ条件で毎回 List 全生成→O(n²))。Items 依存の挙動 (不正行での空リストfallback) は維持
+            for (int i = 0; i < count; i++)
                 if (GetItemChecked(i))
                 {
                     n++;

--- a/PDIndexer/FormAboutMe.cs
+++ b/PDIndexer/FormAboutMe.cs
@@ -37,17 +37,10 @@ public partial class FormAboutMe : FormBase //260604Cl Form→FormBase (F1ヘル
     {
         labelVersion.Text = "PDIndexer   " + Version.VersionAndDate;
 
-        string str = "";
-
-        str += Version.Introduction + "\r\n\r\n";//はじめに
-        str += Version.CopyRight + "\r\n\r\n";//著作権
-        str += Version.Condition + "\r\n\r\n";//実行条件
-        str += Version.Exemption + "\r\n\r\n";//免責
-        str += Version.Adress + "\r\n\r\n";//連絡先
-        str += Version.Acknowledge + "\r\n\r\n";//謝辞
-        str += Version.History;//履歴
-
-        textBoxReadMe.Text += str;
+        // 260712Cl 記法近代化: 7回の str += 連結を string.Join 1式に集約
+        textBoxReadMe.Text += string.Join("\r\n\r\n",
+            Version.Introduction, Version.CopyRight, Version.Condition,
+            Version.Exemption, Version.Adress, Version.Acknowledge, Version.History);//はじめに/著作権/実行条件/免責/連絡先/謝辞/履歴
     }
 
     private void linkLabelHomePage_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)

--- a/PDIndexer/FormAboutMe.cs
+++ b/PDIndexer/FormAboutMe.cs
@@ -28,7 +28,7 @@ public partial class FormAboutMe : FormBase //260604Cl Form→FormBase (F1ヘル
     {
         try
         {
-            System.Diagnostics.Process.Start("mailto:" + linkLabelMail.Text);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo("mailto:" + linkLabelMail.Text) { UseShellExecute = true }); //260712Cl バグ修正: 旧 Process.Start(string)。.NET Core以降は UseShellExecute=false 既定でmailtoを開けず空catchで握り潰されていた (FormMain:4008と同方針)
         }
         catch { }
     }
@@ -47,7 +47,7 @@ public partial class FormAboutMe : FormBase //260604Cl Form→FormBase (F1ヘル
     {
         try
         {
-            System.Diagnostics.Process.Start(linkLabelHomePage.Text);
+            System.Diagnostics.Process.Start(new System.Diagnostics.ProcessStartInfo(linkLabelHomePage.Text) { UseShellExecute = true }); //260712Cl バグ修正: 旧 Process.Start(string) はURLを開けず無反応 (FormMain:4008と同方針)
         }
         catch { }
     }

--- a/PDIndexer/FormAtomicPositionFinder.Designer.cs
+++ b/PDIndexer/FormAtomicPositionFinder.Designer.cs
@@ -1174,7 +1174,6 @@
             graphControl1.AllowMouseOperation = true;
             graphControl1.AxisLineColor = System.Drawing.Color.Gray;
             graphControl1.AxisTextColor = System.Drawing.Color.Black;
-            graphControl1.AxisTextFont = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             graphControl1.AxisXTextVisible = true;
             graphControl1.AxisYTextVisible = true;
             graphControl1.BackgroundColor = System.Drawing.Color.White;

--- a/PDIndexer/FormAtomicPositionFinder.cs
+++ b/PDIndexer/FormAtomicPositionFinder.cs
@@ -41,6 +41,8 @@ namespace PDIndexer
             var elemTipRm = new System.ComponentModel.ComponentResourceManager(typeof(FormAtomicPositionFinder));
             string elemTip = elemTipRm.GetString("numericTexBox.SharedToolTip");
 
+            //260712Cl 224個の同一Fontを共有1インスタンスに集約
+            var arialFont = new Font("Arial", 8.25F, FontStyle.Regular, GraphicsUnit.Point, 0);
             for (int i = 0; i < 112; i++)
             {
                 numericTexBox.Add(new NumericBox());
@@ -48,15 +50,15 @@ namespace PDIndexer
                 numericTexBox[i].Size = new Size(29, 20);
                 label[i].Size = new Size(22, 20);
                 label[i].ForeColor = Color.Blue; ;
-                numericTexBox[i].Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-                label[i].Font = new System.Drawing.Font("Arial", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+                numericTexBox[i].Font = arialFont; //260712Cl 共有Fontインスタンス
+                label[i].Font = arialFont;
                 label[i].TextAlign = ContentAlignment.MiddleRight;
 
                 if (i != 0)
                 {
                     this.tabPage2.Controls.Add(numericTexBox[i]);
                     this.tabPage2.Controls.Add(label[i]);
-                    numericTexBox[i].ValueChanged += new NumericBox.MyEventHandler(numerictextBoxElement_ValueChanged);
+                    numericTexBox[i].ValueChanged += numerictextBoxElement_ValueChanged; //260712Cl メソッドグループ変換
                     toolTip.SetToolTip(numericTexBox[i], elemTip); // 260531Cl 追加: 元素入力箱の共通ツールチップ
                 }
             }
@@ -86,117 +88,20 @@ namespace PDIndexer
                 numericTexBox[i].Location = new Point(label[i].Location.X + label[i].Width + 2, label[i].Location.Y);
 
             #region テキストの設定
-            label[1].Text = "H";
-            label[2].Text = "He";
-            label[3].Text = "Li";
-            label[4].Text = "Be";
-            label[5].Text = "B";
-            label[6].Text = "C";
-            label[7].Text = "N";
-            label[8].Text = "O";
-            label[9].Text = "F";
-            label[10].Text = "Ne";
-            label[11].Text = "Na";
-            label[12].Text = "Mg";
-            label[13].Text = "Al";
-            label[14].Text = "Si";
-            label[15].Text = "P";
-            label[16].Text = "S";
-            label[17].Text = "Cl";
-            label[18].Text = "Ar";
-            label[19].Text = "K";
-            label[20].Text = "Ca";
-            label[21].Text = "Sc";
-            label[22].Text = "Ti";
-            label[23].Text = "V";
-            label[24].Text = "Cr";
-            label[25].Text = "Mn";
-            label[26].Text = "Fe";
-            label[27].Text = "Co";
-            label[28].Text = "Ni";
-            label[29].Text = "Cu";
-            label[30].Text = "Zn";
-            label[31].Text = "Ga";
-            label[32].Text = "Ge";
-            label[33].Text = "As";
-            label[34].Text = "Se";
-            label[35].Text = "Br";
-            label[36].Text = "Kr";
-            label[37].Text = "Rb";
-            label[38].Text = "Sr";
-            label[39].Text = "Y";
-            label[40].Text = "Zr";
-            label[41].Text = "Nb";
-            label[42].Text = "Mo";
-            label[43].Text = "Tc";
-            label[44].Text = "Ru";
-            label[45].Text = "Rh";
-            label[46].Text = "Pd";
-            label[47].Text = "Ag";
-            label[48].Text = "Cd";
-            label[49].Text = "In";
-            label[50].Text = "Sn";
-            label[51].Text = "Sb";
-            label[52].Text = "Te";
-            label[53].Text = "I";
-            label[54].Text = "Xe";
-            label[55].Text = "Cs";
-            label[56].Text = "Ba";
-            label[57].Text = "La";
-            label[58].Text = "Ce";
-            label[59].Text = "Pr";
-            label[60].Text = "Nd";
-            label[61].Text = "Pm";
-            label[62].Text = "Sm";
-            label[63].Text = "Eu";
-            label[64].Text = "Gd";
-            label[65].Text = "Tb";
-            label[66].Text = "Dy";
-            label[67].Text = "Ho";
-            label[68].Text = "Er";
-            label[69].Text = "Tm";
-            label[70].Text = "Yb";
-            label[71].Text = "Lu";
-            label[72].Text = "Hf";
-            label[73].Text = "Ta";
-            label[74].Text = "W";
-            label[75].Text = "Re";
-            label[76].Text = "Os";
-            label[77].Text = "Ir";
-            label[78].Text = "Pt";
-            label[79].Text = "Au";
-            label[80].Text = "Hg";
-            label[81].Text = "Tl";
-            label[82].Text = "Pb";
-            label[83].Text = "Bi";
-            label[84].Text = "Po";
-            label[85].Text = "At";
-            label[86].Text = "Rn";
-            label[87].Text = "Fr";
-            label[88].Text = "Ra";
-            label[89].Text = "Ac";
-            label[90].Text = "Th";
-            label[91].Text = "Pa";
-            label[92].Text = "U";
-            label[93].Text = "Np";
-            label[94].Text = "Pu";
-            label[95].Text = "Am";
-            label[96].Text = "Cm";
-            label[97].Text = "Bk";
-            label[98].Text = "Cf";
-            label[99].Text = "Es";
-            label[100].Text = "Fm";
-            label[101].Text = "Md";
-            label[102].Text = "No";
-            label[103].Text = "Lr";
-            label[104].Text = "Rf";
-            label[105].Text = "Db";
-            label[106].Text = "Sg";
-            label[107].Text = "Bh";
-            label[108].Text = "Hs";
-            label[109].Text = "Mt";
-            label[110].Text = "Ds";
-            label[111].Text = "Rg";
+            // 260712Cl 記法近代化: 元素記号の代入111行を collection expression 配列 + ループに集約
+            string[] symbols = ["", "H", "He", "Li", "Be", "B", "C", "N", "O", "F", "Ne",
+                "Na", "Mg", "Al", "Si", "P", "S", "Cl", "Ar", "K", "Ca",
+                "Sc", "Ti", "V", "Cr", "Mn", "Fe", "Co", "Ni", "Cu", "Zn",
+                "Ga", "Ge", "As", "Se", "Br", "Kr", "Rb", "Sr", "Y", "Zr",
+                "Nb", "Mo", "Tc", "Ru", "Rh", "Pd", "Ag", "Cd", "In", "Sn",
+                "Sb", "Te", "I", "Xe", "Cs", "Ba", "La", "Ce", "Pr", "Nd",
+                "Pm", "Sm", "Eu", "Gd", "Tb", "Dy", "Ho", "Er", "Tm", "Yb",
+                "Lu", "Hf", "Ta", "W", "Re", "Os", "Ir", "Pt", "Au", "Hg",
+                "Tl", "Pb", "Bi", "Po", "At", "Rn", "Fr", "Ra", "Ac", "Th",
+                "Pa", "U", "Np", "Pu", "Am", "Cm", "Bk", "Cf", "Es", "Fm",
+                "Md", "No", "Lr", "Rf", "Db", "Sg", "Bh", "Hs", "Mt", "Ds", "Rg"];
+            for (int i = 1; i <= 111; i++)
+                label[i].Text = symbols[i];
 
             #endregion
 
@@ -280,7 +185,7 @@ namespace PDIndexer
             //まず数字と原子の間にスペースをいれる
             string inputFormula = textBoxInputFormula.Text;
             for (int i = 0; i < inputFormula.Length - 1; i++)
-                if ('0' <= inputFormula[i] && '9' >= inputFormula[i] && 'A' <= inputFormula[i + 1] && 'z' >= inputFormula[i + 1])
+                if (inputFormula[i] is >= '0' and <= '9' && inputFormula[i + 1] is >= 'A' and <= 'z') //260712Cl 関係パターン
                     inputFormula = inputFormula.Insert(i + 1, " ");//数字とアルファベットが並んでいたらスペースを挿入
 
             //スペース区切りで分割
@@ -291,7 +196,7 @@ namespace PDIndexer
             //文字列が2つ以上の元素名で構成されていたら分割
             for (int i = 0; i < dividedFormula.Count; i++)
             {
-                if ('A' <= dividedFormula[i][0] && 'z' >= dividedFormula[i][0])//最初がアルファベットで始まっていたら
+                if (dividedFormula[i][0] is >= 'A' and <= 'z')//最初がアルファベットで始まっていたら //260712Cl 関係パターン
                 {
                     bool flag = false;
                     for (int j = dividedFormula[i].Length; j > 0 && flag == false; j--)
@@ -302,8 +207,8 @@ namespace PDIndexer
                                 flag = true;
                                 if (j != dividedFormula[i].Length)
                                 {
-                                    dividedFormula.Insert(i, dividedFormula[i].Substring(0, j));
-                                    dividedFormula[i + 1] = dividedFormula[i + 1].Substring(j);
+                                    dividedFormula.Insert(i, dividedFormula[i][..j]); //260712Cl Substring → 範囲演算子
+                                    dividedFormula[i + 1] = dividedFormula[i + 1][j..];
                                 }
                                 break;
                             }
@@ -312,12 +217,9 @@ namespace PDIndexer
                 }
                 else
                 {
-                    try
-                    {
-                        double d = Convert.ToDouble(dividedFormula[i]);
+                    //260712Cl try/catch+Convert.ToDouble → double.TryParse
+                    if (double.TryParse(dividedFormula[i], out var d))
                         temp2.Add(d);
-                    }
-                    catch { }
                 }
             }
 
@@ -327,10 +229,10 @@ namespace PDIndexer
             string formulaInUnitCell = "";
             for (int i = 0; i < temp2.Count; i++)
             {
-                while (i < temp2.Count && temp2[i].GetType() != typeof(int))
+                while (i < temp2.Count && temp2[i] is not int) //260712Cl is パターン
                     temp2.RemoveAt(i);
 
-                if (i < temp2.Count - 1 && temp2[i + 1].GetType() == typeof(double))//次が数字のときは
+                if (i < temp2.Count - 1 && temp2[i + 1] is double)//次が数字のときは //260712Cl is パターン
                 {
                     numericTexBox[(int)temp2[i]].Value += (double)temp2[i + 1] * (double)numericUpDownZ.Value;
 
@@ -341,7 +243,7 @@ namespace PDIndexer
                         formulaInUnitCell += label[(int)temp2[i]].Text + (numericTexBox[(int)temp2[i]].Value).ToString();
                     i++;
                 }
-                else if ((i < temp2.Count - 1 && temp2[i + 1].GetType() == typeof(int)) || i == temp2.Count - 1)//次が元素のとき、あるいは次がないとき
+                else if ((i < temp2.Count - 1 && temp2[i + 1] is int) || i == temp2.Count - 1)//次が元素のとき、あるいは次がないとき //260712Cl is パターン
                 {
                     numericTexBox[(int)temp2[i]].Value += 1.0 * (double)numericUpDownZ.Value;
 
@@ -561,16 +463,14 @@ namespace PDIndexer
                 Symmetry s = SymmetryStatic.Symmetries[i];
                 if (s.CrystalSystemNumber == comboBoxCrystalSystem.SelectedIndex + 1)
                 {
-                    string str = "";
-                    str += $"{s.SpaceGroupNumber}.{s.SpaceGroupSubNumber}"; //260317Cl 文字列連結 → 文字列補間
-                    str += ": ";
-                    str += s.SpaceGroupHMStr;
-                    if (str.IndexOf("=") > 0)
-                        str = str.Substring(0, str.IndexOf("="));
-                    if (str.IndexOf("(") > 0)
-                        str = str.Substring(0, str.IndexOf("("));
-                    if (str.IndexOf("Hex") > 0)
-                        str = str.Substring(0, str.IndexOf("Hex"));
+                    string str = $"{s.SpaceGroupNumber}.{s.SpaceGroupSubNumber}: {s.SpaceGroupHMStr}"; //260712Cl 4行の連結 → 補間1式
+                    //260712Cl char版IndexOf(ordinal) + 範囲演算子
+                    if (str.IndexOf('=') > 0)
+                        str = str[..str.IndexOf('=')];
+                    if (str.IndexOf('(') > 0)
+                        str = str[..str.IndexOf('(')];
+                    if (str.IndexOf("Hex", StringComparison.Ordinal) > 0)
+                        str = str[..str.IndexOf("Hex", StringComparison.Ordinal)];
                     str = str.TrimEnd(' '); //260317Cl new char[] → char
                     listBoxSpaceGroupCandidate.Items.Add(str);
                 }
@@ -579,6 +479,11 @@ namespace PDIndexer
         }
 
         #region 空間群選択のlistBoxのオーナードロー
+        // 260712Cl メモリ: DrawItem 毎回生成の4フォントを static フィールドへ巻き上げ (アプリ寿命、Dispose不要)
+        private static readonly Font sub = new("Times New Roman", 8f, FontStyle.Regular);
+        private static readonly Font italic = new("Times New Roman", 11f, FontStyle.Italic);
+        private static readonly Font regular = new("Times New Roman", 11f, FontStyle.Regular);
+        private static readonly Font bold = new("Times New Roman", 10f, FontStyle.Bold);
         private void listBox1_DrawItem(object sender, DrawItemEventArgs e)
         {
             e.DrawBackground();
@@ -586,17 +491,11 @@ namespace PDIndexer
 
             //下付き文字用フォント
             //Font sub = new Font("Times New Roman", 8f, FontStyle.Regular); // (260624Ch) 旧: Font が未破棄
-            using var sub = new Font("Times New Roman", 8f, FontStyle.Regular); // (260624Ch)
             //斜体
             //Font italic = new Font("Times New Roman", 11f, FontStyle.Italic); // (260624Ch) 旧: Font が未破棄
-            using var italic = new Font("Times New Roman", 11f, FontStyle.Italic); // (260624Ch)
             //普通
             //Font regular = new Font("Times New Roman", 11f, FontStyle.Regular); // (260624Ch) 旧: Font が未破棄
-            using var regular = new Font("Times New Roman", 11f, FontStyle.Regular); // (260624Ch)
-
             //Font bold = new Font("Times New Roman", 10f, FontStyle.Bold); // (260624Ch) 旧: Font が未破棄
-            using var bold = new Font("Times New Roman", 10f, FontStyle.Bold); // (260624Ch)
-
             float xPos = e.Bounds.Left;
             //Brush b = null; // (260624Ch) 旧: 手動 Dispose
 
@@ -604,36 +503,40 @@ namespace PDIndexer
             //    b = new SolidBrush(Color.Black);
             //else
             //    b = new SolidBrush(Color.White);
-            using var b = (e.State & DrawItemState.Selected) != DrawItemState.Selected
-                ? new SolidBrush(Color.Black)
-                : new SolidBrush(Color.White); // (260624Ch)
+            var b = (e.State & DrawItemState.Selected) != DrawItemState.Selected
+                ? Brushes.Black
+                : Brushes.White; //260712Cl キャッシュ済み静的ブラシに置換 (Dispose不要)
             e.Graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
 
 
             //最初に数値を書く
-            e.Graphics.DrawString(txt.Substring(0, txt.IndexOf(':')), bold, b, xPos, e.Bounds.Y + 1);
-            xPos += e.Graphics.MeasureString(txt.Substring(0, txt.IndexOf(':')), bold).Width - 3;
+            //260712Cl IndexOf 3回→1回, 部分文字列を範囲演算子で
+            int colon = txt.IndexOf(':');
+            string head = txt[..colon];
+            e.Graphics.DrawString(head, bold, b, xPos, e.Bounds.Y + 1);
+            xPos += e.Graphics.MeasureString(head, bold).Width - 3;
 
-            txt = txt.Substring(txt.IndexOf(':'));
+            txt = txt[colon..];
 
             while (txt.Length > 0)
             {
-                if (txt.StartsWith(" "))
+                if (txt.StartsWith(' ')) //260712Cl StartsWith(char)
                     xPos += 0;
                 else if (txt.StartsWith("sub"))//subで始まる時は
                 {
                     xPos -= 1;
-                    txt = txt.Substring(3, txt.Length - 3);
+                    txt = txt[3..]; //260712Cl Substring → 範囲演算子
                     e.Graphics.DrawString(txt[0].ToString(), sub, b, xPos, e.Bounds.Y + 3);
                     xPos += e.Graphics.MeasureString(txt[0].ToString(), sub).Width - 2;
                 }
 
-                else if (txt.StartsWith("-"))//-で始まる時は
+                else if (txt.StartsWith('-'))//-で始まる時は //260712Cl StartsWith(char)
                 {
                     float x = e.Graphics.MeasureString(txt[1].ToString(), regular).Width;
                     //e.Graphics.DrawLine(new Pen(b, 1), new PointF(xPos + 2f, e.Bounds.Y + 1), new PointF(x + xPos - 3f, e.Bounds.Y + 1)); // (260624Ch) 旧: Pen が未破棄
-                    using var linePen = new Pen(b, 1); // (260624Ch)
-                    e.Graphics.DrawLine(linePen, new PointF(xPos + 2f, e.Bounds.Y + 1), new PointF(x + xPos - 3f, e.Bounds.Y + 1)); // (260624Ch)
+                    //260712Cl 幅1の静的ペンに置換 (Dispose不要)
+                    var linePen = (e.State & DrawItemState.Selected) != DrawItemState.Selected ? Pens.Black : Pens.White;
+                    e.Graphics.DrawLine(linePen, new PointF(xPos + 2f, e.Bounds.Y + 1), new PointF(x + xPos - 3f, e.Bounds.Y + 1));
                 }
                 else if (txt[0] == '/')
                 {
@@ -641,7 +544,7 @@ namespace PDIndexer
                     e.Graphics.DrawString(txt[0].ToString(), regular, b, xPos, e.Bounds.Y);
                     xPos += e.Graphics.MeasureString(txt[0].ToString(), regular).Width - 5;
                 }
-                else if (('0' <= txt[0] && '9' >= txt[0]) || txt[0] == ':')
+                else if (txt[0] is (>= '0' and <= '9') or ':') //260712Cl 関係パターン+orパターン
                 {
                     e.Graphics.DrawString(txt[0].ToString(), regular, b, xPos, e.Bounds.Y);
                     xPos += e.Graphics.MeasureString(txt[0].ToString(), regular).Width - 2;
@@ -651,7 +554,7 @@ namespace PDIndexer
                     e.Graphics.DrawString(txt[0].ToString(), italic, b, xPos, e.Bounds.Y);
                     xPos += e.Graphics.MeasureString(txt[0].ToString(), italic).Width - 2;
                 }
-                txt = txt.Substring(1);
+                txt = txt[1..]; //260712Cl Substring → 範囲演算子
             }
 
             //b.Dispose(); // (260624Ch) using var に移行
@@ -833,12 +736,13 @@ namespace PDIndexer
 
             //ワイコフ位置だけが決まっている（原子位置は決まっていない)結晶候補リストを作成
             List<Crystal[]> crystalTemplates = []; //260317Cl new List<Crystal[]>() → []
+            var atomSpeciesArray = atomSpecies.ToArray(); //260712Cl 二重ループ外へ巻き上げ
             for (int i = 0; i < candidate.Count; i++)
             {
                 crystalTemplates.Add(new Crystal[candidate[i].Length]);
                 for (int j = 0; j < candidate[i].Length; j++)
                 {
-                    crystalTemplates[i][j] = generateCrystalTemplates((Crystal)crystal[i].Clone(), candidate[i][j], atomSpecies.ToArray());
+                    crystalTemplates[i][j] = generateCrystalTemplates((Crystal)crystal[i].Clone(), candidate[i][j], atomSpeciesArray); //260712Cl 巻き上げた配列を再利用
                     ConvertCrystalData.SetOpenGL_property(crystalTemplates[i][j]);//描画用のプロパティをセット
 
                     for (int k = 0; k < crystalTemplates[i][j].Atoms.Length; k++)
@@ -973,7 +877,7 @@ namespace PDIndexer
                             if (checkAtomicPosition(tempCrystal))
                             {
                                 tempCrystal.SetPeakIntensity(WaveSource.Xray, WaveColor.Monochrome, waveLengthControl1.WaveLength,null);
-                                tempCrystal.Residual = GetResidualValue(observedIntensity, getIntensityArray(tempCrystal));
+                                tempCrystal.Residual = GetResidualValue(observedIntensity, tempCrystal.Plane); //260712Cl 中間 double[] を排除
                                 candidates.Add(tempCrystal);
                             }
                         }
@@ -982,7 +886,7 @@ namespace PDIndexer
                             int i = r.Next(r.Next(r.Next(candidates.Count)));
                             if (rnd < randomizeProb + hybridizeProb)//遺伝アルゴリズム リスト中の掛け合わせ
                             {
-                                Crystal tempCrystal = hybridizeCrystals(new Crystal[] { candidates[i], candidates[r.Next(i)] });
+                                Crystal tempCrystal = hybridizeCrystals([candidates[i], candidates[r.Next(i)]]); //260712Cl collection expression
                                 if (checkAtomicPosition(tempCrystal))//原子位置に重なりがなければ
                                 {
                                     tempCrystal.SetPeakIntensity(WaveSource.Xray, WaveColor.Monochrome, waveLengthControl1.WaveLength, null);
@@ -1050,6 +954,7 @@ namespace PDIndexer
                 allCandidate.Sort();
                 if (allCandidate.Count > maxCandidate)
                     allCandidate.RemoveRange(maxCandidate, allCandidate.Count - maxCandidate);
+                var noteSb = new StringBuilder(); //260712Cl Note構築をStringBuilder再利用に (iループ外で1個確保)
                 for (int i = 0; i < allCandidate.Count; i++)
                 {
                     while (i < allCandidate.Count && double.IsNaN(allCandidate[i].Residual))
@@ -1057,13 +962,12 @@ namespace PDIndexer
 
                     allCandidate[i].ReCoordinateAtom();
 
-                    allCandidate[i].Note = allCandidate[i].Symmetry.SpaceGroupHMStr + ", ";
-                    for (int j = 0; j < allCandidate[i].Atoms.Length; j++)
-                    {
-                        allCandidate[i].Note +=
-                            allCandidate[i].Atoms[j].Label + "  " + allCandidate[i].Atoms[j].WyckoffLeter + ": " +
-                            allCandidate[i].Atoms[j].X.ToString("f3") + "," + allCandidate[i].Atoms[j].Y.ToString("f3") + "," + allCandidate[i].Atoms[j].Z.ToString("f3") + "; ";
-                    }
+                    //260712Cl 記法近代化+メモリ: Note構築を StringBuilder 再利用に
+                    noteSb.Clear().Append(allCandidate[i].Symmetry.SpaceGroupHMStr).Append(", ");
+                    foreach (var atom in allCandidate[i].Atoms)
+                        noteSb.Append(atom.Label).Append("  ").Append(atom.WyckoffLeter).Append(": ")
+                              .Append(atom.X.ToString("f3")).Append(',').Append(atom.Y.ToString("f3")).Append(',').Append(atom.Z.ToString("f3")).Append("; ");
+                    allCandidate[i].Note = noteSb.ToString();
 
                     if (i > 0 && allCandidate[i - 1].Note == allCandidate[i].Note)
                         allCandidate.RemoveAt(i--);
@@ -1084,7 +988,7 @@ namespace PDIndexer
             if (crystals[0].SymmetrySeriesNumber != crystals[1].SymmetrySeriesNumber) return null;
 
             //まずcrystal2から原子を一つ選ぶ
-            Random r = new Random();
+            var r = Random.Shared; //260712Cl new Random()→Random.Shared (ワーカーループから呼ばれるたびに生成していた; スレッドセーフ)
             List<int> elementList = []; //260317Cl new List<int>() → []
             for (int i = 0; i < crystals[0].Atoms.Length; i++)
                 if (!elementList.Contains(crystals[0].Atoms[i].AtomicNumber))
@@ -1107,8 +1011,8 @@ namespace PDIndexer
         {
             if (c == null || c.Atoms == null || c.Atoms.Length < 1) return false;
 
-            List<Vector3DBase> v = []; //260317Cl new List<Vector3DBase>() → []
-            List<double> r = []; //260317Cl new List<double>() → []
+            List<Vector3DBase> v = new(c.Atoms.Length); //260712Cl 初期容量指定 (ホットパス: 試行結晶ごとに呼ばれる)
+            List<double> r = new(c.Atoms.Length); //260712Cl
             for (int i = 0; i < c.Atoms.Length; i++)
             {
                 Vector3DBase temp = (c.Atoms[i].Atom[0].X * c.A_Axis + c.Atoms[i].Atom[0].Y * c.B_Axis + c.Atoms[i].Atom[0].Z * c.C_Axis);
@@ -1140,9 +1044,9 @@ namespace PDIndexer
 
         int maxCandidate = 1000;
         int aggregateStep = 10000;
-        Profile top1 = new Profile();
-        Profile top10 = new Profile();
-        Profile top100 = new Profile();
+        Profile top1 = new(); //260712Cl target-typed new
+        Profile top10 = new();
+        Profile top100 = new();
 
         private void backgroundWorker_ProgressChanged(object sender, ProgressChangedEventArgs e)
         {
@@ -1226,6 +1130,26 @@ namespace PDIndexer
             return residual / observedIntensity.Length*1000;
         }
 
+        //260712Cl 追加: List<Plane> を直接読み中間 double[] を排除するオーバーロード
+        public double GetResidualValue(double[] observedIntensity, List<Plane> plane)
+        {
+            double sum1 = 0, sum2 = 0;
+            for (int i = 0; i < observedIntensity.Length; i++)
+            {
+                double calc = plane[i].Intensity;
+                sum1 += calc * calc;
+                sum2 += observedIntensity[i] * calc;
+            }
+            double A = sum2 / sum1;
+            double residual = 0;
+            for (int i = 0; i < observedIntensity.Length; i++)
+            {
+                double d = A * plane[i].Intensity - observedIntensity[i];
+                residual += d * d;
+            }
+            return residual / observedIntensity.Length * 1000;
+        }
+
 
         public Crystal generateCrystalTemplates(Crystal crystal, int[][] wykcoffCandidate, int[] atomSpecies)
         {
@@ -1273,9 +1197,7 @@ namespace PDIndexer
             int[][] housingAtom = new int[atom.Length][];
             for (int i = 0; i < atom.Length; i++)
             {
-                housingAtom[i] = new int[multiplicity.Length];
-                for (int j = 0; j < housingAtom[i].Length; j++)
-                    housingAtom[i][j] = 0;
+                housingAtom[i] = new int[multiplicity.Length]; //260712Cl 冗長な0初期化ループを削除 (配列は生成時に0初期化保証)
             }
             return GenerateWyckoff(atom, multiplicity, housingAtom, freedom);
         }
@@ -1321,14 +1243,11 @@ namespace PDIndexer
                     int[][] tempHousingAtom = new int[residualAtom.Length][];
                     for (int j = 0; j < tempHousingAtom.Length; j++)
                     {
-                        tempHousingAtom[j] = new int[multiplicity.Length];
-                        for (int k = 0; k < tempHousingAtom[j].Length; k++)
-                            tempHousingAtom[j][k] = housingAtom[j][k];
+                        tempHousingAtom[j] = [.. housingAtom[j]]; //260712Cl 要素コピーループ → スプレッド
                     }
                     tempHousingAtom[targetAtom][i] += 1;
 
-                    int[] tempResidualAtom = new int[residualAtom.Length];
-                    residualAtom.CopyTo(tempResidualAtom, 0);
+                    int[] tempResidualAtom = [.. residualAtom]; //260712Cl new+CopyTo → スプレッド
                     tempResidualAtom[targetAtom] -= multiplicity[i];
 
                     if (targetAtom == tempResidualAtom.Length - 1 && tempResidualAtom[targetAtom] == 0)
@@ -1337,7 +1256,7 @@ namespace PDIndexer
                     {
                         List<int[][]> answerList = GenerateWyckoff(tempResidualAtom, multiplicity, tempHousingAtom, freedom);
                         if (answerList.Count > 0)
-                            answer.AddRange(answerList.ToArray());
+                            answer.AddRange(answerList); //260712Cl 不要な ToArray コピーを削除
                     }
                 }
             }
@@ -1362,7 +1281,7 @@ namespace PDIndexer
             using var dlg = new OpenFileDialog(); // (260624Ch)
             if (dlg.ShowDialog() == DialogResult.OK)
             {
-                System.Xml.Serialization.XmlSerializer serializer = new System.Xml.Serialization.XmlSerializer(typeof(AtomicPositionFinderIO));
+                System.Xml.Serialization.XmlSerializer serializer = new(typeof(AtomicPositionFinderIO)); //260712Cl target-typed new
                 try
                 {
                     //System.IO.FileStream fs = new System.IO.FileStream(dlg.FileName, System.IO.FileMode.Open); // (260624Ch) 旧: 例外時に Close されない
@@ -1492,7 +1411,7 @@ namespace PDIndexer
             using var dlg = new SaveFileDialog(); // (260624Ch)
             if (dlg.ShowDialog() == DialogResult.OK)
             {
-                System.Xml.Serialization.XmlSerializer serializer = new System.Xml.Serialization.XmlSerializer(typeof(AtomicPositionFinderIO));
+                System.Xml.Serialization.XmlSerializer serializer = new(typeof(AtomicPositionFinderIO)); //260712Cl target-typed new
                 //System.IO.FileStream fs = new System.IO.FileStream(dlg.FileName, System.IO.FileMode.Create); // (260624Ch) 旧: 例外時に Close されない
                 using var fs = new System.IO.FileStream(dlg.FileName, System.IO.FileMode.Create); // (260624Ch)
                 serializer.Serialize(fs, a);
@@ -1596,13 +1515,13 @@ namespace PDIndexer
             {
                 IDataObject data = Clipboard.GetDataObject();
                 String str = (String)data.GetData(typeof(String));
-                String[] strList = str.Split(new string[] { "\r\n" },  StringSplitOptions.RemoveEmptyEntries);
+                string[] strList = str.Split("\r\n", StringSplitOptions.RemoveEmptyEntries); //260712Cl string オーバーロード
                 dataSet.DataTableDiffractionData.Rows.Clear();
                 if (strList != null)
                 {
                     for (int i = 0; i < strList.Length; i++)
                     {
-                        String[] temp = strList[i].Split(new string[] { "\t" }, StringSplitOptions.RemoveEmptyEntries);
+                        string[] temp = strList[i].Split('\t', StringSplitOptions.RemoveEmptyEntries); //260712Cl char オーバーロード
 
                         dataSet.DataTableDiffractionData.Rows.Add(true, Convert.ToDouble(temp[0]), Convert.ToDouble(temp[4]));
                     }

--- a/PDIndexer/FormCellFinder.cs
+++ b/PDIndexer/FormCellFinder.cs
@@ -160,6 +160,10 @@ namespace PDIndexer
         {
             if (!isFinding) //260625Cl 旧: if (buttonFind.Text == "Find!")
             {
+                //260712Cl バグ修正: 直前のStop(CancelAsyncは非同期)でワーカーがまだ動作中(IsBusy)のうちに再Findすると、
+                //  下の Candidates.Clear() / Tables[1].Clear() がワーカーの AddRange/Sort とレースしてListが壊れる。動作中は開始しない。
+                if (backgroundWorker.IsBusy)
+                    return;
                 //まずクリアする
                 dataSet1.Tables[1].Clear();
                 Candidates.Clear();
@@ -831,7 +835,9 @@ namespace PDIndexer
 
         private void backgroundWorker_RunWorkerCompleted(object sender, RunWorkerCompletedEventArgs e)
         {
-
+            //260712Cl バグ修正: 旧は空実装で、DoWork 内の例外 (Parallel.For の AggregateException 含む) が e.Error に入ったまま黙殺されていた。最低限ユーザーへ通知する。
+            if (e.Error != null)
+                MessageBox.Show(e.Error.Message, "Cell finder", MessageBoxButtons.OK, MessageBoxIcon.Warning);
         }
 
         private void loadToolStripMenuItem_Click(object sender, EventArgs e)

--- a/PDIndexer/FormCellFinder.cs
+++ b/PDIndexer/FormCellFinder.cs
@@ -48,17 +48,15 @@ namespace PDIndexer
                 Low = low;
 
                 //配列dに信頼が高い順番にd値を格納する
-                D = new double[high.Length + medium.Length + low.Length];
-                for (int i = 0; i < high.Length; i++) D[i] = high[i];
-                for (int i = 0; i < medium.Length; i++) D[i + high.Length] = medium[i];
-                for (int i = 0; i < low.Length; i++) D[i + high.Length + medium.Length] = low[i];
+                D = [.. high, .. medium, .. low]; //260712Cl 3配列連結→スプレッド
 
                 WaveLength = wavelength;
 
                 SortedD = new Plane[D.Length];
-                for (int i = 0; i < high.Length; i++) SortedD[i] = new Plane(high[i], 0, 0, 0, 1, 1 / Math.Pow((Math.Asin(wavelength / 2 / high[i]) * 2), 2));
-                for (int i = 0; i < medium.Length; i++) SortedD[i + high.Length] = new Plane(medium[i], 0, 0, 0, 0.5, 1 / Math.Pow((Math.Asin(wavelength / 2 / medium[i]) * 2), 2));
-                for (int i = 0; i < low.Length; i++) SortedD[i + high.Length + medium.Length] = new Plane(low[i], 0, 0, 0, 0.1, 1 / Math.Pow((Math.Asin(wavelength / 2 / low[i]) * 2), 2));
+                // 260712Cl 記法近代化: Math.Pow(x,2)→乗算 (2θを一時変数tに)
+                for (int i = 0; i < high.Length; i++) { var t = 2 * Math.Asin(wavelength / 2 / high[i]); SortedD[i] = new Plane(high[i], 0, 0, 0, 1, 1 / (t * t)); }
+                for (int i = 0; i < medium.Length; i++) { var t = 2 * Math.Asin(wavelength / 2 / medium[i]); SortedD[i + high.Length] = new Plane(medium[i], 0, 0, 0, 0.5, 1 / (t * t)); }
+                for (int i = 0; i < low.Length; i++) { var t = 2 * Math.Asin(wavelength / 2 / low[i]); SortedD[i + high.Length + medium.Length] = new Plane(low[i], 0, 0, 0, 0.1, 1 / (t * t)); }
                 Array.Sort(SortedD);
                 Array.Reverse(SortedD);
 
@@ -87,7 +85,7 @@ namespace PDIndexer
             }
             public object[] GenerateRow()
             {
-                return new object[] { A * 10, B * 10, C * 10, Alpha / Math.PI * 180, Beta / Math.PI * 180, Gamma / Math.PI * 180, Volume * 1000, SigmaDQ, R, Planes };
+                return [A * 10, B * 10, C * 10, Alpha / Math.PI * 180, Beta / Math.PI * 180, Gamma / Math.PI * 180, Volume * 1000, SigmaDQ, R, Planes]; //260712Cl new object[]→[]
             }
 
             #region IComparable メンバ
@@ -131,7 +129,7 @@ namespace PDIndexer
             distributionGraphControl1.BackgroundColor = Color.Gray;
             distributionGraphControl1.DivisionLineColor = Color.Black;
 
-            int[][] c = new int[][] { new int[] { 0, 0, 0, 0 }, new int[] { 5376, 0, 0, 255 }, new int[] { 16256, 0, 191, 191 }, new int[] { 27136, 0, 255, 0 }, new int[] { 38016, 255, 255, 0 }, new int[] { 48896, 255, 0, 0 }, new int[] { 59904, 255, 0, 255 }, new int[] { 65535, 255, 255, 255 } };
+            int[][] c = [[0, 0, 0, 0], [5376, 0, 0, 255], [16256, 0, 191, 191], [27136, 0, 255, 0], [38016, 255, 255, 0], [48896, 255, 0, 0], [59904, 255, 0, 255], [65535, 255, 255, 255]]; //260712Cl ジャグ配列→[]
 
             for (int i = 0; i < 65536; i++)
             {
@@ -146,7 +144,7 @@ namespace PDIndexer
 
         private void buttonAddPeak_Click(object sender, EventArgs e)
         {
-            dataSet1.Tables[0].Rows.Add(new object[] { numericalTextBox1.Value, comboBoxReliability.Text, true });
+            dataSet1.Tables[0].Rows.Add(numericalTextBox1.Value, comboBoxReliability.Text, true); //260712Cl new object[]→params
         }
 
         private void dataGridView1_CellContentClick(object sender, DataGridViewCellEventArgs e)
@@ -184,17 +182,16 @@ namespace PDIndexer
                 high.Sort(); medium.Sort(); low.Sort();
                 high.Reverse(); medium.Reverse(); low.Reverse();
 
-                int unk = 0;
-                switch (comboBoxCrystalSystem.SelectedIndex)
+                // 260712Cl 記法近代化: switch文→switch式
+                int unk = comboBoxCrystalSystem.SelectedIndex switch
                 {
-                    case 0: unk = 6; break; //triclinic
-                    case 1: unk = 4; break;//monoclinic
-                    case 2: unk = 3; break; //orthorhombic
-                    case 3: unk = 2; break; //tetragonal
-                    case 4: unk = 2; break; //trigonal
-                    case 5: unk = 2; break; //hexagonal
-                    case 6: unk = 1; break; //cubic
-                }
+                    0 => 6, //triclinic
+                    1 => 4, //monoclinic
+                    2 => 3, //orthorhombic
+                    3 or 4 or 5 => 2, //tetragonal, trigonal, hexagonal
+                    6 => 1, //cubic
+                    _ => 0
+                };
                 if (unk > high.Count + medium.Count + low.Count)
                     return;
                 isFinding = true; //260625Cl 追加
@@ -222,11 +219,11 @@ namespace PDIndexer
         {
             FindCondition condition = (FindCondition)e.Argument;
 
-            Candidate[][] c = new Candidate[threadTotal][];
+            var c = new List<Candidate>[threadTotal]; //260712Cl 旧: Candidate[][] c = new Candidate[threadTotal][];
 
             int counter = 0;
             int lastCounter = 0;
-            Random r = new Random();
+            Random r = new(); //260712Cl target-typed new
             int tryNumber = 10000;
             while (!backgroundWorker.CancellationPending)
             {
@@ -264,7 +261,8 @@ namespace PDIndexer
             }
         }
 
-        private Candidate[] GetCandidates(FindCondition condition, int seed, int tryNumber)
+        //260712Cl 旧シグネチャ: private Candidate[] GetCandidates(FindCondition condition, int seed, int tryNumber)
+        private List<Candidate> GetCandidates(FindCondition condition, int seed, int tryNumber)
         {
             var r = new Random(seed);
             List<Candidate> c = []; //260317Cl new List<Candidate>() → []
@@ -274,44 +272,43 @@ namespace PDIndexer
                 if (temp.R < 1000)
                     c.Add(temp);
             }
-            return c.ToArray();
+            return c; //260712Cl 旧: return c.ToArray();
         }
 
-        private Candidate FindCellParameter(FindCondition condition, int seed)
+        private Candidate FindCellParameter(in FindCondition condition, int seed) //260712Cl in 参照渡し (旧: 値渡し)
         {
-            Random r = new Random(seed);
-            int unk = 0;
-            switch (condition.CrystalSystem)
+            Random r = new(seed); //260712Cl target-typed new
+            // 260712Cl 記法近代化: switch文→switch式
+            int unk = condition.CrystalSystem switch
             {
-                case 0: unk = 6; break; //triclinic
-                case 1: unk = 4; break;//monoclinic
-                case 2: unk = 3; break; //orthorhombic
-                case 3: unk = 2; break; //tetragonal
-                case 4: unk = 2; break; //trigonal
-                case 5: unk = 2; break; //hexagonal
-                case 6: unk = 1; break; //cubic
-            }
+                0 => 6, //triclinic
+                1 => 4, //monoclinic
+                2 => 3, //orthorhombic
+                3 or 4 or 5 => 2, //tetragonal, trigonal, hexagonal
+                6 => 1, //cubic
+                _ => 0
+            };
             if (unk > condition.DtoSortedD.Length)
                 return new Candidate();
 
             Plane[] planes = new Plane[unk];
 
             //まず対象となるピークをunk本選ぶ 
-            List<int> targetPeak = []; //260317Cl new List<int>() → []
+            Span<int> targetPeak = stackalloc int[unk]; //260712Cl 旧: List<int> targetPeak = []; (ホットパスの毎回アロケーション除去)
             for (int j = 0; j < unk; j++)
             {
-                targetPeak.Sort();
+                targetPeak[..j].Sort();
                 int tempTarget = r.Next(r.Next(condition.DtoSortedD.Length / 2));
-                for (int n = 0; n < targetPeak.Count; n++) //0からtempTargetの間で既に選ばれている指数を検索し、tempTargetから外す
+                for (int n = 0; n < j; n++) //0からtempTargetの間で既に選ばれている指数を検索し、tempTargetから外す
                     if (tempTarget >= targetPeak[n])
                         tempTarget++;
-                targetPeak.Add(tempTarget);
+                targetPeak[j] = tempTarget;
             }
             targetPeak.Sort();
             //ピーク選定おわり
 
             //次にピークに指数を与える
-            for (int j = 0; j < targetPeak.Count; j++)
+            for (int j = 0; j < targetPeak.Length; j++) //260712Cl .Count→.Length (Span化)
             {
                 //指数を生成する  orthoは h,k,lすべて >= 0 指数の上限は　ピークの順番(何番目の要素か)の値に6を足したもの
                 int h = 0, k = 0, l = 0;
@@ -350,9 +347,10 @@ namespace PDIndexer
             //軸を組み替える
             if (condition.CrystalSystem == 2)//orthoのとき
             {
-                if (c.A < c.B) { double temp = c.A; c.A = c.B; c.B = temp; }
-                if (c.B < c.C) { double temp = c.B; c.B = c.C; c.C = temp; }
-                if (c.A < c.B) { double temp = c.A; c.A = c.B; c.B = temp; }
+                // 260712Cl 記法近代化: タプルスワップ
+                if (c.A < c.B) (c.A, c.B) = (c.B, c.A);
+                if (c.B < c.C) (c.B, c.C) = (c.C, c.B);
+                if (c.A < c.B) (c.A, c.B) = (c.B, c.A);
             }
             if (condition.CrystalSystem == 1)//monoclinicのとき
             {//βがもっとも90°に近くなるように
@@ -360,15 +358,16 @@ namespace PDIndexer
              // c.C = 0.5242;
              // c.Beta = 105.7 / 180.0 * Math.PI;
 
-                PointD u = new PointD(c.A, 0);
-                PointD v = new PointD(c.C * Math.Cos(c.Beta), c.C * Math.Sin(c.Beta));
+                // 260712Cl 記法近代化: target-typed new
+                PointD u = new(c.A, 0);
+                PointD v = new(c.C * Math.Cos(c.Beta), c.C * Math.Sin(c.Beta));
                 double area = c.A * c.C * Math.Sin(c.Beta);
                 List<PointD> p = []; //260317Cl new List<PointD>() → []
                 for (int i = -2; i <= 2; i++)
                     for (int j = -2; j <= 2; j++)
                         if (!(i == 0 && j == 0))
                             p.Add(i * u + j * v);
-                PointD temp1 = new PointD(0, 0), temp2 = new PointD(0, 0);
+                PointD temp1 = new(0, 0), temp2 = new(0, 0); //260712Cl target-typed new
                 double tempBeta = double.MaxValue;
                 for (int i = 0; i < p.Count; i++)
                     for (int j = i + 1; j < p.Count; j++)
@@ -386,7 +385,7 @@ namespace PDIndexer
                 c.C = temp2.Length;
                 c.Beta = tempBeta;
 
-                if (c.A < c.C) { double temp = c.A; c.A = c.C; c.C = temp; }
+                if (c.A < c.C) (c.A, c.C) = (c.C, c.A); //260712Cl タプルスワップ
             }
             if (condition.MaxA >= c.A && condition.MinA <= c.A && condition.MaxB >= c.B && condition.MinB <= c.B && condition.MaxC >= c.C && condition.MinC <= c.C
              && condition.MaxAlpha >= c.Alpha && condition.MinAlpha <= c.Alpha && condition.MaxBeta >= c.Beta && condition.MinBeta <= c.Beta && condition.MaxGamma >= c.Gamma && condition.MinGamma <= c.Gamma)
@@ -397,7 +396,7 @@ namespace PDIndexer
 
         private Candidate GetResidualValue(Candidate c, FindCondition condition, int seed)
         {
-            Random r = new Random(seed);
+            Random r = new(seed); //260712Cl target-typed new
             double SinAlpha = Math.Sin(c.Alpha); double SinBeta = Math.Sin(c.Beta); double SinGamma = Math.Sin(c.Gamma);
             double CosAlpha = Math.Cos(c.Alpha); double CosBeta = Math.Cos(c.Beta); double CosGamma = Math.Cos(c.Gamma);
             double a2 = c.A * c.A; double b2 = c.B * c.B; double c2 = c.C * c.C;
@@ -414,9 +413,7 @@ namespace PDIndexer
             int kMax = Math.Min((int)(c.B / (condition.SortedD[^1].D * 0.9)), 30);
             int lMax = Math.Min((int)(c.C / (condition.SortedD[^1].D * 0.9)), 30);
 
-            Plane[] obs = new Plane[condition.SortedD.Length];
-            for (int i = 0; i < obs.Length; i++)
-                obs[i] = condition.SortedD[i];
+            Plane[] obs = [.. condition.SortedD]; //260712Cl 要素コピーループ→スプレッド
 
             //計算上のd値を格納するリストを定義
             List<Plane> calcPlanes = []; //260317Cl new List<Plane>() → []
@@ -494,10 +491,7 @@ namespace PDIndexer
                         diff[i] = temp;
                         obsToCalcIndex[i] = j;
                     }
-            double diffMax = double.NegativeInfinity;
-            for (int i = 0; i < obs.Length; i++)
-                if (diffMax < diff[i])
-                    diffMax = diff[i];
+            double diffMax = diff.Max(); //260712Cl 手動max→diff.Max() (SimdLinq)
             if (diffMax > 0.0004) return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
 
             //obsToCalcに重複がないかどうかチェック
@@ -563,21 +557,21 @@ namespace PDIndexer
             int column = p.Length;
             Matrix<double> inv;
 
-            int unk = 0;
-            switch (system)
+            // 260712Cl 記法近代化: switch文→switch式
+            int unk = system switch
             {
-                case 0: unk = 6; break; //triclinic
-                case 1: unk = 4; break;//monoclinic
-                case 2: unk = 3; break; //orthorhombic
-                case 3: unk = 2; break; //tetragonal
-                case 4: unk = 2; break; //trigonal
-                case 5: unk = 2; break; //hexagonal
-                case 6: unk = 1; break; //cubic
-            }
+                0 => 6, //triclinic
+                1 => 4, //monoclinic
+                2 => 3, //orthorhombic
+                3 or 4 or 5 => 2, //tetragonal, trigonal, hexagonal
+                6 => 1, //cubic
+                _ => 0
+            };
             var Q = new DenseMatrix(column, unk);
             var A = new DenseMatrix(column, 1);
             var W = new DenseMatrix(column, column);
             Matrix<double> C = new DenseMatrix(column, 1);
+            Matrix<double> Qt = null; //260712Cl 追加: 下の switch 各 case で Q.Transpose() を1回に集約 (case 群はスコープを共有するため式の外で宣言)
 
             switch (system)
             {
@@ -595,10 +589,11 @@ namespace PDIndexer
                         W[i, i] = p[i].Weight * p[i].Reliability;
                     }
 
-                    if (!(Q.Transpose() * W * Q).TryInverse(out inv))
+                    Qt = Q.Transpose(); //260712Cl 変更: switch 手前で宣言した Qt へ代入 (Transpose を case 内で1回に集約)
+                    if (!(Qt * W * Q).TryInverse(out inv))
                         return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
 
-                    C = inv * Q.Transpose() * W * A;
+                    C = inv * Qt * W * A;
 
                     double a_star = Math.Sqrt(C[0, 0]);
                     double b_star = Math.Sqrt(C[1, 0]);
@@ -685,10 +680,11 @@ namespace PDIndexer
                         W[i, i] = p[i].Weight * p[i].Reliability;
                     }
 
-                    if (!(Q.Transpose() * W * Q).TryInverse(out inv))
+                    Qt = Q.Transpose(); //260712Cl 変更: switch 手前で宣言した Qt へ代入 (Transpose を case 内で1回に集約)
+                    if (!(Qt * W * Q).TryInverse(out inv))
                         return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
 
-                    C = inv * Q.Transpose() * W * A;
+                    C = inv * Qt * W * A;
 
                     beta = Math.Acos(-C[3, 0] / 2 / Math.Sqrt(C[0, 0] * C[2, 0]));
                     a = Math.Sqrt(1 / C[0, 0]) / Math.Sin(beta);
@@ -709,9 +705,10 @@ namespace PDIndexer
                         A[i, 0] = 1 / p[i].D / p[i].D;
                         W[i, i] = p[i].Weight * p[i].Reliability;
                     }
-                    if (!(Q.Transpose() * W * Q).TryInverse(out inv))
+                    Qt = Q.Transpose(); //260712Cl 変更: switch 手前で宣言した Qt へ代入 (Transpose を case 内で1回に集約)
+                    if (!(Qt * W * Q).TryInverse(out inv))
                         return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
-                    C = inv * Q.Transpose() * W * A;
+                    C = inv * Qt * W * A;
 
                     a = Math.Sqrt(1 / C[0, 0]);
                     b = Math.Sqrt(1 / C[1, 0]);
@@ -731,9 +728,10 @@ namespace PDIndexer
                         W[i, i] = p[i].Weight * p[i].Reliability;
                     }
 
-                    if (!(Q.Transpose() * W * Q).TryInverse(out inv))
+                    Qt = Q.Transpose(); //260712Cl 変更: switch 手前で宣言した Qt へ代入 (Transpose を case 内で1回に集約)
+                    if (!(Qt * W * Q).TryInverse(out inv))
                         return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
-                    C = inv * Q.Transpose() * W * A;
+                    C = inv * Qt * W * A;
 
                     a = b = Math.Sqrt(1 / C[0, 0]);
                     c = Math.Sqrt(1 / C[1, 0]);
@@ -751,9 +749,10 @@ namespace PDIndexer
                         A[i, 0] = 1 / p[i].D / p[i].D;
                         W[i, i] = p[i].Weight * p[i].Reliability;
                     }
-                    if (!(Q.Transpose() * W * Q).TryInverse(out inv))
+                    Qt = Q.Transpose(); //260712Cl 変更: switch 手前で宣言した Qt へ代入 (Transpose を case 内で1回に集約)
+                    if (!(Qt * W * Q).TryInverse(out inv))
                         return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
-                    C = inv * Q.Transpose() * W * A;
+                    C = inv * Qt * W * A;
 
                     a = b = Math.Sqrt(1 / C[0, 0]);
                     c = Math.Sqrt(1 / C[1, 0]);
@@ -772,9 +771,10 @@ namespace PDIndexer
                         A[i, 0] = 1 / p[i].D / p[i].D;
                         W[i, i] = p[i].Weight * p[i].Reliability;
                     }
-                    if (!(Q.Transpose() * W * Q).TryInverse(out inv))
+                    Qt = Q.Transpose(); //260712Cl 変更: switch 手前で宣言した Qt へ代入 (Transpose を case 内で1回に集約)
+                    if (!(Qt * W * Q).TryInverse(out inv))
                         return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
-                    C = inv * Q.Transpose() * W * A;
+                    C = inv * Qt * W * A;
 
                     a = b = Math.Sqrt(1 / C[0, 0]);
                     c = Math.Sqrt(1 / C[1, 0]);
@@ -792,9 +792,10 @@ namespace PDIndexer
                         A[i, 0] = 1 / p[i].D / p[i].D;
                         W[i, i] = p[i].Weight * p[i].Reliability;
                     }
-                    if (!(Q.Transpose() * W * Q).TryInverse(out inv))
+                    Qt = Q.Transpose(); //260712Cl 変更: switch 手前で宣言した Qt へ代入 (Transpose を case 内で1回に集約)
+                    if (!(Qt * W * Q).TryInverse(out inv))
                         return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
-                    C = inv * Q.Transpose() * W * A;
+                    C = inv * Qt * W * A;
 
                     a = b = c = Math.Sqrt(1 / C[0, 0]);
                     alpha = beta = gamma = Math.PI / 2;
@@ -806,7 +807,8 @@ namespace PDIndexer
                 return new Candidate(0, 0, 0, 0, 0, 0, 0, double.PositiveInfinity, double.PositiveInfinity, null);
             else
             {
-                sigmaDQ = ((C.Transpose() * Q.Transpose() - A.Transpose()) * W * (Q * C - A))[0, 0];
+                var res = Q * C - A; //260712Cl 残差ベクトルを再利用 (旧: (C.Transpose() * Q.Transpose() - A.Transpose()) * W * (Q * C - A))
+                sigmaDQ = (res.Transpose() * W * res)[0, 0];
                 return new Candidate(a, b, c, alpha, beta, gamma, V, sigmaDQ, 0, p);
             }
         }
@@ -842,17 +844,12 @@ namespace PDIndexer
                 try
                 {
                     //StreamReader reader = new StreamReader(dlg.FileName, Encoding.GetEncoding("UTF-8")); // (260624Ch) 旧: 例外時に Close されない
-                    using var reader = new StreamReader(dlg.FileName, Encoding.GetEncoding("UTF-8")); // (260624Ch)
-                    List<string> strList = []; //260317Cl new List<string>() → []
-                    string tempstr;
-                    while ((tempstr = reader.ReadLine()) != null)
-                        strList.Add(tempstr);
-                    //reader.Close(); // (260624Ch) using var に移行
+                    var strList = File.ReadAllLines(dlg.FileName, Encoding.UTF8); //260712Cl StreamReaderループ→File.ReadAllLines
 
                     dataSet1.Tables[0].Rows.Clear();
                     Candidates.Clear();
-                    for (int i = 3; i < strList.Count; i++)
-                        dataSet1.Tables[0].Rows.Add(new object[] { Convert.ToDouble(strList[i]), "High", true });
+                    for (int i = 3; i < strList.Length; i++)
+                        dataSet1.Tables[0].Rows.Add(Convert.ToDouble(strList[i]), "High", true); //260712Cl new object[]→params
                 }
                 catch { }
             }
@@ -903,35 +900,35 @@ namespace PDIndexer
             if (dataSet1.Tables[1].Rows.Count < 1) return;
             double minR = (double)dataSet1.Tables[1].Rows[0][8];
 
-            double maxR = (double)dataSet1.Tables[1].Rows[dataSet1.Tables[1].Rows.Count - 1][8];
+            double maxR = (double)dataSet1.Tables[1].Rows[^1][8]; //260712Cl Count-1→^1
 
             //pictureBoxに分布を描く
             distributionGraphControl1.ClearData();
             for (int i = dataSet1.Tables[1].Rows.Count - 1; i >= 0; i--)
             {
-                double x = 0, y = 0;
-                switch (comboBoxX.Text)
+                // 260712Cl 記法近代化: switch文→switch式 (x, y)
+                double x = comboBoxX.Text switch
                 {
-                    case "a": x = (double)dataSet1.Tables[1].Rows[i][0]; break;
-                    case "b": x = (double)dataSet1.Tables[1].Rows[i][1]; break;
-                    case "c": x = (double)dataSet1.Tables[1].Rows[i][2]; break;
-                    case "α": x = (double)dataSet1.Tables[1].Rows[i][3]; break;
-                    case "β": x = (double)dataSet1.Tables[1].Rows[i][4]; break;
-                    case "γ": x = (double)dataSet1.Tables[1].Rows[i][5]; break;
-                }
-                switch (comboBoxY.Text)
+                    "a" => (double)dataSet1.Tables[1].Rows[i][0],
+                    "b" => (double)dataSet1.Tables[1].Rows[i][1],
+                    "c" => (double)dataSet1.Tables[1].Rows[i][2],
+                    "α" => (double)dataSet1.Tables[1].Rows[i][3],
+                    "β" => (double)dataSet1.Tables[1].Rows[i][4],
+                    "γ" => (double)dataSet1.Tables[1].Rows[i][5],
+                    _ => 0
+                };
+                double y = comboBoxY.Text switch
                 {
-                    case "a": y = (double)dataSet1.Tables[1].Rows[i][0]; break;
-                    case "b": y = (double)dataSet1.Tables[1].Rows[i][1]; break;
-                    case "c": y = (double)dataSet1.Tables[1].Rows[i][2]; break;
-                    case "α": y = (double)dataSet1.Tables[1].Rows[i][3]; break;
-                    case "β": y = (double)dataSet1.Tables[1].Rows[i][4]; break;
-                    case "γ": y = (double)dataSet1.Tables[1].Rows[i][5]; break;
-                }
+                    "a" => (double)dataSet1.Tables[1].Rows[i][0],
+                    "b" => (double)dataSet1.Tables[1].Rows[i][1],
+                    "c" => (double)dataSet1.Tables[1].Rows[i][2],
+                    "α" => (double)dataSet1.Tables[1].Rows[i][3],
+                    "β" => (double)dataSet1.Tables[1].Rows[i][4],
+                    "γ" => (double)dataSet1.Tables[1].Rows[i][5],
+                    _ => 0
+                };
                 double r = (double)dataSet1.Tables[1].Rows[i][8];
-                int index = (int)(65535 * ((maxR - r) / (maxR - minR)));
-                if (index < 1) index = 0;
-                if (index > 65535) index = 65535;
+                int index = Math.Clamp((int)(65535 * ((maxR - r) / (maxR - minR))), 0, 65535); //260712Cl 手動範囲制限→Math.Clamp
 
                 distributionGraphControl1.AddData(new PointD(x, y), 5, 5, color[index], color[index], 0, false);
 

--- a/PDIndexer/FormCrystal.Designer.cs
+++ b/PDIndexer/FormCrystal.Designer.cs
@@ -652,7 +652,7 @@ namespace PDIndexer
             // FormCrystal
             // 
             resources.ApplyResources(this, "$this");
-            AutoScaleMode = AutoScaleMode.Font;
+            AutoScaleMode = AutoScaleMode.Dpi;
             Controls.Add(splitContainer1);
             Controls.Add(statusStrip1);
             KeyPreview = true;

--- a/PDIndexer/FormCrystal.cs
+++ b/PDIndexer/FormCrystal.cs
@@ -118,6 +118,9 @@ public partial class FormCrystal : FormBase //260604Cl Form→FormBase (F1ヘル
             //Graphics g = Graphics.FromImage(bmp); // (260624Ch) 旧: Graphics が未破棄
             using (var g = Graphics.FromImage(bmp)) // (260624Ch)
                 g.Clear(Color.FromArgb(cry.Argb));
+            //260712Cl バグ修正(GDIリーク): 旧Bitmapを破棄せず列[2]を上書きしていたため、結晶色変更のたびに22x22 Bitmapハンドルがリークしていた。差し替え前に旧Bitmapを破棄 (is パターンで null/DBNull は素通り)。
+            if (dataSet.DataTableCrystal.Rows[bindingSource.Position][2] is Bitmap oldBmp)
+                oldBmp.Dispose();
             dataSet.DataTableCrystal.Rows[bindingSource.Position][1] = cry;
             dataSet.DataTableCrystal.Rows[bindingSource.Position][2] = bmp;
             formMain.InitializeCrystalPlane();

--- a/PDIndexer/FormCrystal.cs
+++ b/PDIndexer/FormCrystal.cs
@@ -42,8 +42,7 @@ public partial class FormCrystal : FormBase //260604Cl Form→FormBase (F1ヘル
     }
     private void FormCrystal_Closed(object sender, System.EventArgs e)
     {
-        if (formMain != null)
-            formMain.checkBoxCrystalParameter.Checked = false;
+        formMain?.checkBoxCrystalParameter.Checked = false; //260712Cl C#14 null条件代入
     }
 
     private void FormCrystal_FormClosing(object sender, FormClosingEventArgs e)
@@ -115,7 +114,7 @@ public partial class FormCrystal : FormBase //260604Cl Form→FormBase (F1ヘル
     {
         if (cry != null && bindingSource.Position >= 0)
         {
-            Bitmap bmp = new Bitmap(22, 22);
+            Bitmap bmp = new(22, 22); //260712Cl target-typed new
             //Graphics g = Graphics.FromImage(bmp); // (260624Ch) 旧: Graphics が未破棄
             using (var g = Graphics.FromImage(bmp)) // (260624Ch)
                 g.Clear(Color.FromArgb(cry.Argb));
@@ -143,7 +142,7 @@ public partial class FormCrystal : FormBase //260604Cl Form→FormBase (F1ヘル
     private void buttonAllClear_Click(object sender, EventArgs e)
     {
         if (MessageBox.Show(PdiText.ClearCrystals, PdiText.TitleWarning, MessageBoxButtons.OKCancel) == DialogResult.OK) //260625Cl 多言語化
-            for (int i = 0; i < dataSet.DataTableCrystal.Items.Count; i++)
+            for (int i = 0; i < dataSet.DataTableCrystal.Rows.Count; i++) //260712Cl Items.Count は毎回 List 全生成のため Rows.Count に
                 if (((Crystal)dataSet.DataTableCrystal.Rows[i][1]).Reserved == false)
                     dataSet.DataTableCrystal.RemoveItem(i--);
     }
@@ -243,7 +242,7 @@ public partial class FormCrystal : FormBase //260604Cl Form→FormBase (F1ヘル
     {
         if (e.Button == MouseButtons.Right)
         {
-            FormNumericUpdownControl formNumericUpdownControl = new FormNumericUpdownControl((NumericUpDown)sender);
+            using var formNumericUpdownControl = new FormNumericUpdownControl((NumericUpDown)sender); //260712Cl ShowDialog は自動 Dispose されないため using 宣言化
             formNumericUpdownControl.ShowDialog();
         }
     }

--- a/PDIndexer/FormCrystal.ja.resx
+++ b/PDIndexer/FormCrystal.ja.resx
@@ -540,7 +540,7 @@
     <value>10</value>
   </data>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>8, 20</value>
+    <value>96, 96</value>
   </data>
   <data name="$this.ClientSize" type="System.Drawing.Size, System.Drawing">
     <value>1088, 782</value>

--- a/PDIndexer/FormCrystal.resx
+++ b/PDIndexer/FormCrystal.resx
@@ -1674,7 +1674,7 @@ of  diffraction peaks based on crystal structures</value>
     <value>45</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
-    <value>7, 17</value>
+    <value>96, 96</value>
   </data>
   <data name="$this.BackgroundImageLayout" type="System.Windows.Forms.ImageLayout, System.Windows.Forms">
     <value>None</value>

--- a/PDIndexer/FormEOS.cs
+++ b/PDIndexer/FormEOS.cs
@@ -159,11 +159,12 @@ public partial class FormEOS : FormBase //260604Cl Form→FormBase (F1ヘルプ�
         //Ross
         numericalTextBoxArRoss.Value = EOS.Ar_Ross(a / 10);
 
-        return new (string Reseacher, double Pressure)[]
-            {
+        // 260712Cl 記法近代化: collection expression
+        return
+            [
         ("Ross86",numericalTextBoxArRoss.Value),
         ("Jephcoat98",numericalTextBoxArJephcoat.Value),
-            };
+            ];
     }
     #endregion
 
@@ -255,10 +256,11 @@ public partial class FormEOS : FormBase //260604Cl Form→FormBase (F1ヘルプ�
         //Dubrovinsky
         numericBoxCorundumDubrovinsky.Value = EOS.Corundum_Dubrovinsky(v0, v, t);
 
-        return new (string Reseacher, double Pressure)[]
-            {
+        // 260712Cl 記法近代化: collection expression
+        return
+            [
                  ("Dubrovinsky98",numericBoxCorundumDubrovinsky.Value),
-            };
+            ];
     }
     #endregion
 
@@ -277,13 +279,14 @@ public partial class FormEOS : FormBase //260604Cl Form→FormBase (F1ヘルプ�
         //Dub
         numericBoxReDub.Value = EOS.BirchMurnaghan4th(342, 6.15, -0.029, 29.46 / v);
 
-        return new (string Reseacher, double Pressure)[]
-         {
+        // 260712Cl 記法近代化: collection expression
+        return
+         [
                  ("Zha04",numericalTextBoxReZha.Value),
                  ("Anz",numericBoxReAnz.Value),
                  ("Sakai",numericBoxReSakai.Value),
                  ("Dub",numericBoxReDub.Value),
-         };
+         ];
     }
     #endregion
 
@@ -323,7 +326,7 @@ public partial class FormEOS : FormBase //260604Cl Form→FormBase (F1ヘルプ�
     #endregion
 
     #region Pb
-    (double T, double B, double Bp)[] PbVinet = new (double T, double B, double Bprime)[] {
+    (double T, double B, double Bp)[] PbVinet = [ //260712Cl collection expression
         #region
         (0,     48.3298,    5.4511),
         (20,    48.2387,    5.4542),
@@ -342,10 +345,10 @@ public partial class FormEOS : FormBase //260604Cl Form→FormBase (F1ヘルプ�
         (280,   41.7317 ,   5.7021),
         (300,   41.2000 ,   5.7245),
         #endregion
-    };
+    ];
 
-    (double T, double A0)[] PbA0 = new (double T, double A0)[]
-    {
+    (double T, double A0)[] PbA0 = //260712Cl collection expression
+    [
         #region
         (   0   ,   4.91366 ),
 (   5   ,   4.91370 ),
@@ -411,7 +414,7 @@ public partial class FormEOS : FormBase //260604Cl Form→FormBase (F1ヘルプ�
 (   305 ,   4.95040 ),
 (   310 ,   4.95110 ),
         #endregion
-    };
+    ];
 
     MathNet.Numerics.Interpolation.IInterpolation PbInterA0, PbInterB, PbInterBp;
     public (string Reseacher, double Pressure)[] Pb()
@@ -437,10 +440,11 @@ public partial class FormEOS : FormBase //260604Cl Form→FormBase (F1ヘルプ�
 
         numericBoxPbStrassle.Value = 3 * B * (1 - x) / x / x * Math.Exp(1.5 * (Bp - 1) * (1 - x));
 
-        return new (string Reseacher, double Pressure)[]
-           {
+        // 260712Cl 記法近代化: collection expression
+        return
+           [
                  ("Strassle14",numericBoxPbStrassle.Value),
-           };
+           ];
     }
     #endregion
 

--- a/PDIndexer/FormExportGSAS.cs
+++ b/PDIndexer/FormExportGSAS.cs
@@ -34,8 +34,8 @@ namespace PDIndexer
             if (formMain.AxisMode == HorizontalAxis.NeutronTOF)
                 div = 1;
 
-            StringBuilder sb = new StringBuilder();
-            DiffractionProfile2 dp = (DiffractionProfile2)((DataRowView)formMain.bindingSourceProfile.Current).Row[1]; ;
+            DiffractionProfile2 dp = (DiffractionProfile2)((DataRowView)formMain.bindingSourceProfile.Current).Row[1];
+            StringBuilder sb = new(dp.Profile.Pt.Count * 38 + 128); //260712Cl 初期容量指定 (1点=38文字×点数): 内部バッファの倍々再確保を回避
 
             //一行目
             string str = dp.Name;
@@ -56,9 +56,9 @@ namespace PDIndexer
                         validErr = true;
                         break;
                     }
+            var value = new string[3]; //260712Cl ループ外へ巻き上げ (毎周の配列割り当てを削減)
             for (int i = 0; i < ptCount; i++)
             {
-                string[] value = new string[3];
                 value[0] = (dp.Profile.Pt[i].X * div).ToString("g12");
                 value[1] = dp.Profile.Pt[i].Y.ToString("g12");
                 if (validErr)
@@ -71,13 +71,12 @@ namespace PDIndexer
                 for (int j = 0; j < value.Length; j++)
                 {
                     if (value[j].Length > 11)
-                        value[j] = value[j].Substring(0, 11);
-                    if (value[j].EndsWith("."))
-                        value[j] = " " + y.Substring(0, 10);
-                    while (value[j].Length < 11)
-                        value[j] = " " + value[j];
+                        value[j] = value[j][..11]; //260712Cl 範囲演算子
+                    if (value[j].EndsWith('.'))
+                        value[j] = " " + y[..10]; //260712Cl
+                    value[j] = value[j].PadLeft(11); //260712Cl while の逐次連結 (最大10回のstring生成) を一括パディングに
                 }
-                sb.Append(" " + value[0] + " " + value[1] + " " + value[2] + "\r\n");
+                sb.Append(' ').Append(value[0]).Append(' ').Append(value[1]).Append(' ').Append(value[2]).Append("\r\n"); //260712Cl 中間文字列の生成を回避
                 
             }
             richTextBoxGsa.Text = sb.ToString();
@@ -152,7 +151,7 @@ namespace PDIndexer
         {
             if(File.Exists(textBoxExpFilePath.Text))
             {
-                StreamReader sr = new StreamReader(textBoxExpFilePath.Text);
+                using var sr = new StreamReader(textBoxExpFilePath.Text); //260712Cl ファイルハンドルリーク対策 (using 宣言)
                 string str;
                 while ((str = sr.ReadLine()) != null)
                 {

--- a/PDIndexer/FormFitting.cs
+++ b/PDIndexer/FormFitting.cs
@@ -208,7 +208,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
                                 "Sym PV" => PeakFunctionForm.PseudoVoigt,
                                 "Sym Pea" => PeakFunctionForm.Peason,
                                 "Spl PV" => PeakFunctionForm.SplitPseudoVoigt,
-                                "Spl Pea" => PeakFunctionForm.SplitPseudoVoigt,
+                                "Spl Pea" => PeakFunctionForm.SplitPearson, //260712Cl バグ修正: 旧 SplitPseudoVoigt (書込側 _=>"Spl Pea" は SplitPearson。保存→再読込で別関数に化けていた)
                                 _ => PeakFunctionForm.PseudoVoigt
                             };
 

--- a/PDIndexer/FormFitting.cs
+++ b/PDIndexer/FormFitting.cs
@@ -32,7 +32,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
         }
     }
 
-    public Profile TargetProfile = new Profile();
+    public Profile TargetProfile = new(); //260712Cl new Profile() → new()
 
     public Crystal temp_crystal;
     public bool IsSkipChangeEvent;
@@ -127,7 +127,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
                     _ => "Spl Pea",
                 };
 
-                sb.Append($"{p.IsFittingChecked.ToString()}\t{p.strHKL}\t{p.XCalc}\t");
+                sb.Append($"{p.IsFittingChecked}\t{p.strHKL}\t{p.XCalc}\t"); //260712Cl 冗長な.ToString()削除
                 if (!double.IsNaN(p.XObs))
                     sb.Append($"{func}\t{p.XObs}\t{p.peakFunction.Xerr}\t{p.peakFunction.Hk}\t{p.observedIntensity}\t{p.peakFunction.Residual * 100}\r\n");
             }
@@ -163,7 +163,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
         var text = generateTableText();
         if (text != "")
         {
-            var dlg = new SaveFileDialog { Filter = "*.csv|*.csv" };
+            using var dlg = new SaveFileDialog { Filter = "*.csv|*.csv" }; //260712Cl using 宣言化
             if (dlg.ShowDialog() == DialogResult.OK)
                 using (StreamWriter sw = new(dlg.FileName, false))
                     sw.Write(text.Replace("\t", ","));
@@ -180,7 +180,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
     private void FormFitting_DragDrop(object sender, DragEventArgs e)
     {
         string[] fileName = (string[])e.Data.GetData(DataFormats.FileDrop, false);
-        if (fileName.Length == 1 && fileName[0].ToLower().EndsWith("csv"))
+        if (fileName.Length == 1 && fileName[0].EndsWith("csv", StringComparison.OrdinalIgnoreCase)) //260712Cl ToLower().EndsWith → OrdinalIgnoreCase
         {
             using var sr = new StreamReader(fileName[0]);
             if (sr.ReadLine().StartsWith("Checked,hkl"))
@@ -188,7 +188,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
                 int n = 0;
                 while (sr.Peek() > -1)
                 {
-                    var line = sr.ReadLine().Split(new[] { ',' }, StringSplitOptions.None);
+                    var line = sr.ReadLine().Split(','); //260712Cl Split簡素化
                     if (line.Length > 2 && n < dataSet.DataTablePeakFitting.Rows.Count)
                     {
                         var dr = dataSet.DataTablePeakFitting.Rows[n] as DataSet.DataTablePeakFittingRow;
@@ -235,13 +235,13 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
         if (!(formMain.bindingSourceProfile.Position >= 0 && (dp = (DiffractionProfile2)((DataRowView)formMain.bindingSourceProfile.Current).Row[1]) != null)) return;
 
         TargetProfile = dp.Profile;
-        var sw = new Stopwatch();
-        sw.Start();
+        var sw = Stopwatch.StartNew(); //260712Cl new Stopwatch()+Start() → StartNew()
 
         var checkedCrystals = formMain.dataSet.DataTableCrystal.CheckedItems;
 
         int groupIndex = 0;
 
+        PointD[] ptArray = null; //260712Cl 追加: Simpleモード用プロファイル配列をループ外で1回だけ生成
         //初期化
         foreach (var c in checkedCrystals)
             foreach (var p in c.Plane.Where(e => e.IsFittingChecked))
@@ -263,7 +263,8 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
 
                 if (p.SerchOption == PeakFunctionForm.Simple) //Simpleもーどのときはここで処理
                 {
-                    p.simpleParameter = FittingPeak.FitPeakAsSimple(p.XCalc, p.SerchRange, TargetProfile.Pt.ToArray());
+                    ptArray ??= TargetProfile.Pt.ToArray(); //260712Cl ループ外で1回だけ生成した配列を使い回し
+                    p.simpleParameter = FittingPeak.FitPeakAsSimple(p.XCalc, p.SerchRange, ptArray);
                     p.XObs = p.simpleParameter.X;
                     p.peakFunction.Xerr = TargetProfile.Pt[1].X - TargetProfile.Pt[0].X;
                 }
@@ -287,11 +288,10 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
             #region すべてをまとめてフィッティング
 
             //全てのフィッティング対象ピークをいったん格納
-            List<PeakFunction> pvpTemp2 = []; //260317Cl new List<PeakFunction>() → []
-            for (int h = 0; h < checkedCrystals.Count; h++)
-                for (int i = 0; i < checkedCrystals[h].Plane.Count; i++)
-                    if (checkedCrystals[h].Plane[i].IsFittingChecked && checkedCrystals[h].Plane[i].SerchOption != PeakFunctionForm.Simple)
-                        pvpTemp2.Add(checkedCrystals[h].Plane[i].peakFunction);
+            // 260712Cl 記法近代化: 二重for+インデクサ → SelectMany/Where/Select
+            List<PeakFunction> pvpTemp2 = [.. checkedCrystals.SelectMany(c => c.Plane)
+                .Where(p => p.IsFittingChecked && p.SerchOption != PeakFunctionForm.Simple)
+                .Select(p => p.peakFunction)];
             //並び替え
             pvpTemp2.Sort();
 
@@ -1091,13 +1091,14 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
         var sb = new StringBuilder();
         if (textBoxA.Text != "0.000000")
         {
-            sb.Append(textBoxA.Text + "\t" + textBoxA_err.Text + "\t");
-            sb.Append(textBoxB.Text + "\t" + textBoxB_err.Text + "\t");
-            sb.Append(textBoxC.Text + "\t" + textBoxC_err.Text + "\t");
-            sb.Append(textBoxAlpha.Text + "\t" + textBoxAlpha_err.Text + "\t");
-            sb.Append(textBoxBeta.Text + "\t" + textBoxBeta_err.Text + "\t");
-            sb.Append(textBoxGamma.Text + "\t" + textBoxGamma_err.Text + "\t");
-            sb.Append(textBoxV.Text + "\t" + textBoxV_err.Text + "\t");
+            // 260712Cl 記法近代化: + 連結 → 文字列補間
+            sb.Append($"{textBoxA.Text}\t{textBoxA_err.Text}\t");
+            sb.Append($"{textBoxB.Text}\t{textBoxB_err.Text}\t");
+            sb.Append($"{textBoxC.Text}\t{textBoxC_err.Text}\t");
+            sb.Append($"{textBoxAlpha.Text}\t{textBoxAlpha_err.Text}\t");
+            sb.Append($"{textBoxBeta.Text}\t{textBoxBeta_err.Text}\t");
+            sb.Append($"{textBoxGamma.Text}\t{textBoxGamma_err.Text}\t");
+            sb.Append($"{textBoxV.Text}\t{textBoxV_err.Text}\t");
             try { Clipboard.SetDataObject(sb.ToString(), true); }
             catch { }
         }
@@ -1158,7 +1159,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
                     if (dataSet.DataTablePeakFitting.Rows.Count >= i + 1)
                     {
                         //チェックされている面指数かどうかを判定して、IsFittingCheckedに反映させる
-                        TargetCrystal.Plane[i].IsFittingChecked = checkedItems.Any(e => e == TargetCrystal.Plane[i].strHKL);
+                        TargetCrystal.Plane[i].IsFittingChecked = checkedItems.Contains(TargetCrystal.Plane[i].strHKL); //260712Cl Any(ラムダ) → Contains
                         dataSet.DataTablePeakFitting.Replace(i, TargetCrystal.Plane[i]);
                     }
                     else
@@ -1189,14 +1190,14 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
                 if (e.ColumnIndex < view.ColumnCount && e.RowIndex < view.RowCount)
                 {
                     var editedFormattedValue = view[e.ColumnIndex, e.RowIndex].EditedFormattedValue;
-                    if (editedFormattedValue != null && editedFormattedValue is bool flag)
+                    if (editedFormattedValue is bool flag) //260712Cl 冗長なnullチェック削除
                     {
                         TargetCrystal.Plane[e.RowIndex].IsFittingChecked = flag;
                         Fitting();
                     }
                 }
             }
-                dataGridViewPlaneList_SelectionChanged(new object(), new EventArgs());
+                dataGridViewPlaneList_SelectionChanged(sender, EventArgs.Empty); //260712Cl new object()/new EventArgs() → sender/EventArgs.Empty
         }
 
         catch { }
@@ -1314,7 +1315,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
     private void buttonApplyRangeToAll_Click(object sender, EventArgs e)
     {
         for (int i = 0; i < TargetCrystal.Plane.Count; i++)
-            TargetCrystal.Plane[i].SerchRange = (double)numericBoxSearchRange.Value / SerchRangeFactor;
+            TargetCrystal.Plane[i].SerchRange = numericBoxSearchRange.Value / SerchRangeFactor; //260712Cl 冗長な(double)キャスト削除
         Fitting();
     }
 
@@ -1376,7 +1377,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
     }
 
     private void NumericBoxEffectiveDigit_ValueChanged(object sender, EventArgs e)
-        => dataGridViewPlaneList.DefaultCellStyle.Format = $"g{numericBoxEffectiveDigit.ValueInteger.ToString()}";
+        => dataGridViewPlaneList.DefaultCellStyle.Format = $"g{numericBoxEffectiveDigit.ValueInteger}"; //260712Cl 冗長な.ToString()削除
 
     private void buttonResetTakeoffAngle_Click(object sender, EventArgs e)
     {
@@ -1447,7 +1448,7 @@ public partial class FormFitting : FormBase //260604Cl Form→FormBase (F1ヘル
         if (TargetCrystal == null || TargetProfile == null) return;
 
         var p = new Profile();
-        p.Pt.AddRange([.. TargetProfile.Pt]);
+        p.Pt.AddRange(TargetProfile.Pt); //260712Cl [.. TargetProfile.Pt] の中間コピーを削除
         if (TargetCrystal.Plane != null)
             foreach (Plane plane in TargetCrystal.Plane)
                 if (plane.IsFittingChecked && plane.SerchOption != PeakFunctionForm.Simple)

--- a/PDIndexer/FormLPO.cs
+++ b/PDIndexer/FormLPO.cs
@@ -141,9 +141,11 @@ namespace PDIndexer
         private void dataGridView1_RowPostPaint(object sender, DataGridViewRowPostPaintEventArgs e)
         {
             if (listStrHkl != null && e.RowIndex < listStrHkl.Count)
-                e.Graphics.DrawString(listStrHkl[e.RowIndex], dataGridView1.DefaultCellStyle.Font, 
-                    new SolidBrush(dataGridView1.RowHeadersDefaultCellStyle.ForeColor), 
+            {
+                using var brush = new SolidBrush(dataGridView1.RowHeadersDefaultCellStyle.ForeColor); //260712Cl GDIブラシをusing宣言で破棄
+                e.Graphics.DrawString(listStrHkl[e.RowIndex], dataGridView1.DefaultCellStyle.Font, brush,
                     e.RowBounds.Location.X + 15, e.RowBounds.Location.Y + 4);
+            }
         }
 
 
@@ -192,7 +194,7 @@ namespace PDIndexer
             }
             for(int i = 0 ; i < crystals.Length ; i++)
                 for(int j=0;j<crystals[i].Contribution.Count ; j++)
-                    list[crystals[i].Contribution[j].i][crystals[i].Contribution[j].m].Add(new int[]{i,j});
+                    list[crystals[i].Contribution[j].i][crystals[i].Contribution[j].m].Add([i, j]); //260712Cl new int[]{i,j} → collection expression
 
             //これでlist[i][m][?]とすればi番目のリングのm番目の角度の回折に寄与する結晶の番号とその結晶の中でのContributionの番号がわかる
             int endCount = 40;
@@ -365,7 +367,7 @@ namespace PDIndexer
 
                 }
 
-                dlg.Text = "Calculating ....  " + residual.ToString();
+                dlg.Text = string.Format(PdiText.CalculatingResidual, residual); //260712Cl 多言語化 (旧: "Calculating ....  " + residual.ToString())
                 DrawPictureBox();
                 Application.DoEvents();
             }
@@ -480,9 +482,9 @@ namespace PDIndexer
         //G空間(phi,z,rho)のマトリックスを作成するメソッド
         private Matrix3D getPhiRhoZ(double phi, double rho, double z)
         {
-            Matrix3D a = new Matrix3D(Math.Cos(phi), Math.Sin(phi), 0, -Math.Sin(phi), Math.Cos(phi), 0, 0, 0, 1);
-            Matrix3D b = new Matrix3D(z, 0, Math.Sqrt(1 - z * z), 0, 1, 0, -Math.Sqrt(1 - z * z), 0, z);
-            Matrix3D c = new Matrix3D(Math.Cos(rho), Math.Sin(rho), 0, -Math.Sin(rho), Math.Cos(rho), 0, 0, 0, 1);
+            Matrix3D a = new(Math.Cos(phi), Math.Sin(phi), 0, -Math.Sin(phi), Math.Cos(phi), 0, 0, 0, 1); //260712Cl target-typed new
+            Matrix3D b = new(z, 0, Math.Sqrt(1 - z * z), 0, 1, 0, -Math.Sqrt(1 - z * z), 0, z);
+            Matrix3D c = new(Math.Cos(rho), Math.Sin(rho), 0, -Math.Sin(rho), Math.Cos(rho), 0, 0, 0, 1);
             return a * b * c;
         }
         private Matrix3D getEuler(double alpha, double phi, double eta)
@@ -729,7 +731,7 @@ namespace PDIndexer
                      if (max < density2[i][j])
                          max = density2[i][j];
 
-             Bitmap bmp = new Bitmap(picturebox.Width, picturebox.Height);
+             Bitmap bmp = new(picturebox.Width, picturebox.Height); //260712Cl target-typed new
 
              double sum = 0;
              for (int i = 0; i < length; i++)

--- a/PDIndexer/FormMain.Designer.cs
+++ b/PDIndexer/FormMain.Designer.cs
@@ -985,7 +985,6 @@ namespace PDIndexer
             resources.ApplyResources(graphControlFrequency, "graphControlFrequency");
             graphControlFrequency.AxisLineColor = Color.Gray;
             graphControlFrequency.AxisTextColor = Color.Black;
-            graphControlFrequency.AxisTextFont = new Font("Segoe UI", 9F);
             graphControlFrequency.AxisXTextVisible = true;
             graphControlFrequency.AxisYTextVisible = true;
             graphControlFrequency.BackgroundColor = Color.White;

--- a/PDIndexer/FormMain.cs
+++ b/PDIndexer/FormMain.cs
@@ -120,11 +120,11 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
             if (UpperX <= LowerX)
                 UpperX++;
         }
-        get { return numericBoxLowerX.Value; }
+        get => numericBoxLowerX.Value; //260712Cl 式本体化
     }
     public double UpperX { set { numericBoxUpperX.Value = value; if (UpperX <= LowerX) LowerX++; } get => numericBoxUpperX.Value; }
     public double LowerY { set { numericBoxLowerY.Value = value; if (UpperY <= LowerY) UpperY++; } get => numericBoxLowerY.Value; }
-    public double UpperY { set { numericBoxUpperY.Value = value; if (UpperY <= LowerY) LowerY--; } get { return numericBoxUpperY.Value; } }
+    public double UpperY { set { numericBoxUpperY.Value = value; if (UpperY <= LowerY) LowerY--; } get => numericBoxUpperY.Value; } //260712Cl 式本体化
 
     public double MaximalX
     {
@@ -297,7 +297,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
     }
 
 
-    private Stopwatch stopwatch { get; set; } = new Stopwatch();
+    private Stopwatch stopwatch { get; set; } = new(); //260712Cl target-typed new
 
 
     #endregion
@@ -648,7 +648,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                         catch { MessageBox.Show(PdiText.ClipboardFail); } //260625Cl 多言語化: 旧 "Failed to read clipboard information. Sorry."
                         finally { mutex.ReleaseMutex(); }
 
-                        if ((int)NextHandle != 0)
+                        if (NextHandle != IntPtr.Zero) //260712Cl IntPtr.Zero 比較
                             SendMessage(NextHandle, msg.Msg, msg.WParam, msg.LParam);
                     }
                     else//mutexを取るのに失敗していたら
@@ -662,7 +662,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
             case WM_CHANGECBCHAIN:
                 if (msg.WParam == NextHandle)
                     NextHandle = (IntPtr)msg.LParam;
-                else if ((int)NextHandle != 0)
+                else if (NextHandle != IntPtr.Zero) //260712Cl IntPtr.Zero 比較
                     SendMessage(NextHandle, msg.Msg, msg.WParam, msg.LParam);
                 break;
         }
@@ -705,7 +705,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
             var key = Microsoft.Win32.Registry.CurrentUser.CreateSubKey("Software\\Crystallography\\PDIndexer");
             try
             {
-                if (4440 > Convert.ToInt32(key.GetValue("Version".Replace(".", ""), "0")))
+                if (4440 > Convert.ToInt32(key.GetValue("Version", "0"))) //260712Cl no-op Replace 除去
                     ClearRegistry();
             }
             catch { ClearRegistry(); }
@@ -830,7 +830,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         FormMacro = new FormMacro(Python.CreateEngine(), macro) { Visible = false };
         FormMacro.HelpPage = "8-macro"; //260604Cl 追加: Controls側マクロフォームにヘルプを設定
 
-        this.Text = "PDIndexer   " + Version.VersionAndDate;
+        this.Text = $"PDIndexer   {Version.VersionAndDate}"; //260712Cl 文字列補間
 #if DEBUG
         this.Text += "(debug)";
 #endif
@@ -913,7 +913,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         initialDialog.Text = "Now Loading... Initializing file system watcher.";
         //ファイル更新監視
         watcher = new FileSystemWatcher { IncludeSubdirectories = true };
-        watcher.Created += new System.IO.FileSystemEventHandler(watcher_Created);
+        watcher.Created += watcher_Created; //260712Cl メソッドグループ
         watcher.Path = "";
         watcher.EnableRaisingEvents = false;
 
@@ -925,8 +925,8 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
 
         initialDialog.Text = "Now Loading... Initializing print function.";
         //プリント関係  
-        printDocument = new System.Drawing.Printing.PrintDocument();
-        printDocument.PrintPage += new System.Drawing.Printing.PrintPageEventHandler(pd_PrintPage);
+        printDocument = new PrintDocument(); //260712Cl フル修飾除去
+        printDocument.PrintPage += pd_PrintPage; //260712Cl メソッドグループ
 
         // PrintPreviewDialogオブジェクトの生成
         printPreviewDialog = new PrintPreviewDialog { Document = printDocument };
@@ -1553,7 +1553,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                 //pen = new Pen(Color.FromArgb(128, Color.FromArgb((int)dp.ColorARGB)), 1) { DashStyle = DashStyle.Dash }; // (260624Ch) 旧: Pen 再代入で前の Pen も未破棄
                 using var originalPen = new Pen(Color.FromArgb(128, Color.FromArgb((int)dp.ColorARGB)), 1) { DashStyle = DashStyle.Dash }; // (260624Ch)
                 if (original.Count > 1)
-                    gMain.DrawLines(originalPen, original.ToArray()); // (260624Ch)
+                    gMain.DrawLines(originalPen, CollectionsMarshal.AsSpan(original)); //260712Cl コピー除去
             }
         }
 
@@ -1569,9 +1569,11 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
 
         try // (260624Ch)
         {
-            Parallel.For(0, dataSet.DataTableProfile.CheckedItems.Count, j =>
+            var checkedItems = dataSet.DataTableProfile.CheckedItems; //260712Cl CheckedItems を1回だけスナップショット
+            var showErrorBar = checkBoxErrorBar.Checked;              //260712Cl UI 状態もループ外で読む
+            Parallel.For(0, checkedItems.Count, j =>
             {
-                var dp = dataSet.DataTableProfile.CheckedItems[j];
+                var dp = checkedItems[j];
                 var srcPts = dp.Profile.Pt.Select(p => new PointD(p.X, p.Y + IntervalOfProfiles * j)).ToArray();
                 if (srcPts.Length > 2)
                 {
@@ -1586,7 +1588,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                     }
 
                     //エラーバー描画
-                    if (checkBoxErrorBar.Checked && dp.SourceProfile.Err != null && dp.SourceProfile.Err.Count == dp.Profile.Pt.Count)
+                    if (showErrorBar && dp.SourceProfile.Err != null && dp.SourceProfile.Err.Count == dp.Profile.Pt.Count)
                     {
                         var penErr = new Pen(Color.FromArgb((int)(pen.Color.R * 0.5), (int)(pen.Color.G * 0.5), (int)(pen.Color.B * 0.5)), pen.Width);
                         lock (lockObj) profilePens.Add(penErr); // (260624Ch)
@@ -1598,9 +1600,9 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                                 var minErr = ConvToPicBoxCoord(srcPts[i].X, srcPts[i].Y - dp.SourceProfile.Err[i].Y);
                                 lock (lockObj)
                                 {
-                                    profiles.Add((penErr, new[] { maxErr, minErr }));
-                                    profiles.Add((penErr, new[] { new PointF(maxErr.X + errbarWidth, maxErr.Y), new PointF(maxErr.X - errbarWidth, maxErr.Y) }));
-                                    profiles.Add((penErr, new[] { new PointF(minErr.X + errbarWidth, minErr.Y), new PointF(minErr.X - errbarWidth, minErr.Y) }));
+                                    profiles.Add((penErr, [maxErr, minErr])); //260712Cl コレクション式
+                                    profiles.Add((penErr, [new PointF(maxErr.X + errbarWidth, maxErr.Y), new PointF(maxErr.X - errbarWidth, maxErr.Y)]));
+                                    profiles.Add((penErr, [new PointF(minErr.X + errbarWidth, minErr.Y), new PointF(minErr.X - errbarWidth, minErr.Y)]));
                                 }
                             }
                     }
@@ -1615,7 +1617,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         }
         finally // (260624Ch)
         {
-            foreach (var pen in profilePens.Distinct())
+            foreach (var pen in profilePens) //260712Cl Distinct 不要 (pen/penErr とも生成時に1回だけ Add)
                 pen.Dispose();
         }
     }
@@ -1662,12 +1664,10 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                             gMain.FillEllipse(pointBrush, p.X - 5, p.Y - 5, 10, 10); // (260624Ch)
                     }
                 }
-                pt = [.. dp.BackgroundProfile.Pt];
-                if (pt.Length > 2)
-                    for (int i = 0; i < pt.Length - 1; i++)
-                    {
-                        gMain.DrawLine(pen, ConvToPicBoxCoord(pt[i]), ConvToPicBoxCoord(pt[i + 1]));
-                    }
+                var bgPt = dp.BackgroundProfile.Pt; //260712Cl コピーせず List を直接参照
+                if (bgPt.Count > 2)
+                    for (int i = 0; i < bgPt.Count - 1; i++)
+                        gMain.DrawLine(pen, ConvToPicBoxCoord(bgPt[i]), ConvToPicBoxCoord(bgPt[i + 1]));
                 for (int i = 0; i < dp.BackgroundProfile.Pt.Count - 1; i++)
                 {
                     gMain.DrawLine(pen, ConvToPicBoxCoord(dp.BackgroundProfile.Pt[i].X, dp.BackgroundProfile.Pt[i].Y + dp.Profile.Pt[i].Y),
@@ -1682,6 +1682,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
     {
         //Pen pen; // (260624Ch) 旧: ループ内生成 Pen が未破棄
 
+        int checkedCrystalCount = dataSet.DataTableCrystal.CheckedItems.Count; //260712Cl メモリ: 面ループ内の CheckedItems 再構築を回避
         //チェックしている結晶の描画位置を計算
         foreach (int i in dataSet.DataTableCrystal.CheckedIndices)
         {
@@ -1697,6 +1698,9 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                     //var br = new SolidBrush(Color.FromArgb(cry.Argb)); // (260624Ch) 旧: Brush が未破棄
                     using var br = new SolidBrush(Color.FromArgb(cry.Argb)); // (260624Ch)
                     using var verticalFormat = new StringFormat(StringFormatFlags.DirectionVertical); // (260624Ch)
+                    // 260712Cl メモリ: Pen を結晶ごとに最大2本へ巻き上げ (面ごとの生成を廃止)
+                    using var basePen = new Pen(Color.FromArgb(cry.Argb), i == bindingSourceCrystal.Position ? 3f : 1f);
+                    using var selectedPen = new Pen(Color.FromArgb(cry.Argb), 5f);
                     var JustBeforePt = new PointF(-10, -10);
                     int shiftY = 40;
                     for (int j = 0; j < cry.Plane.Count; j++)
@@ -1709,9 +1713,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                             //pen = i == bindingSourceCrystal.Position ? // (260624Ch) 旧: Pen が未破棄
                             //     new Pen(Color.FromArgb(cry.Argb), j == SelectedPlaneIndex ? 5f : 3f) :
                             //     new Pen(Color.FromArgb(cry.Argb), 1f);
-                            using var pen = i == bindingSourceCrystal.Position ?
-                                 new Pen(Color.FromArgb(cry.Argb), j == SelectedPlaneIndex ? 5f : 3f) :
-                                 new Pen(Color.FromArgb(cry.Argb), 1f); // (260624Ch)
+                            var pen = (i == bindingSourceCrystal.Position && j == SelectedPlaneIndex) ? selectedPen : basePen; //260712Cl 巻き上げた basePen/selectedPen を選択
 
                             if (!double.IsNaN(cry.Plane[j].XCalc))
                             {
@@ -1720,7 +1722,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                                     if (formCrystal.checkBoxShowPeakOverProfiles.Checked)
                                     {
                                         float zero = formCrystal.checkBoxShowPeakUnderProfile.Checked ?//描画範囲の最低強度位置のピクセル
-                                            pictureBoxMain.Height - OriginPos.Y - dataSet.DataTableCrystal.CheckedItems.Count * (HeightOfBottomPeaks + 4) :
+                                            pictureBoxMain.Height - OriginPos.Y - checkedCrystalCount * (HeightOfBottomPeaks + 4) : //260712Cl 巻き上げた checkedCrystalCount を使用
                                             pictureBoxMain.Height - OriginPos.Y;
 
                                         float top = 0;
@@ -1810,8 +1812,8 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         List<Plane> planeList = []; //260317Cl new List<T>() → []
 
         //先ず、fittigチェックの結晶面を探す。
-        for (int c = 0; c < dataSet.DataTableCrystal.CheckedItems.Count; c++)
-            planeList.AddRange(dataSet.DataTableCrystal.CheckedItems[c].Plane.Where(p => p.IsFittingChecked).ToArray());
+        foreach (var cry in dataSet.DataTableCrystal.CheckedItems) //260712Cl getter 1回化 + 中間 ToArray 削除
+            planeList.AddRange(cry.Plane.Where(p => p.IsFittingChecked));
 
         //simpleモードのものだけ抜き出して、描画
         foreach (Plane p in planeList.Where(p => p.SerchOption == PeakFunctionForm.Simple && !p.simpleParameter.IsNaN && !double.IsNaN(p.simpleParameter.X)))
@@ -1833,7 +1835,9 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         try
         {
             //グループごとに描画
-            for (int i = planeList2.Min(p => p.peakFunction.GroupIndex); i < planeList2.Max(p => p.peakFunction.GroupIndex) + 1; i++)
+            int minGroup = planeList2.Min(p => p.peakFunction.GroupIndex); //260712Cl ループ外へ巻き上げ
+            int maxGroup = planeList2.Max(p => p.peakFunction.GroupIndex);
+            for (int i = minGroup; i <= maxGroup; i++)
             {
                 //i番目のグループを抜き出す。
                 Plane[] planeList3 = planeList.Where(p => p.peakFunction.GroupIndex == i).ToArray();
@@ -1860,10 +1864,10 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                         }
 
                     if (subtraction.Count > 1)
-                        gMain.DrawLines(penSubtraction, subtraction.ToArray());
+                        gMain.DrawLines(penSubtraction, CollectionsMarshal.AsSpan(subtraction)); //260712Cl コピー除去 (ReadOnlySpan オーバーロード)
 
                     if (background.Count > 1)
-                        gMain.DrawLines(penSubtraction, background.ToArray());
+                        gMain.DrawLines(penSubtraction, CollectionsMarshal.AsSpan(background));
 
                     //個々のフィッティングカーブを描く
                     foreach (Plane p in planeList3)
@@ -1880,7 +1884,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                                 for (double k = startTheta; k < endTheta; k += step)
                                     peaks.Add(ConvToPicBoxCoord(k, p.peakFunction.GetValue(k, false) + p.peakFunction.B1 + p.peakFunction.B2 * (k - p.peakFunction.X) + basePosition));
                                 if (peaks.Count > 1)
-                                    gMain.DrawLines(penPeak, peaks.ToArray());
+                                    gMain.DrawLines(penPeak, CollectionsMarshal.AsSpan(peaks)); //260712Cl コピー除去
                             }
                         }
                     }
@@ -1889,6 +1893,9 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         }
         catch { }
     }
+
+    // 260712Cl メモリ: 描画ホットパスで共有する不変 Font (アプリ寿命保持のため Dispose 不要)
+    private static readonly Font tahoma8 = new("Tahoma", 8);
 
     //目盛りを描画する部分
     private void DrawGradiation()
@@ -1916,8 +1923,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
 
         gMain.DrawLine(pen, OriginPos.X, pictureBoxMain.Height - OriginPos.Y, pictureBoxMain.Width, pictureBoxMain.Height - OriginPos.Y);
         //using Font strFont = new(new FontFamily("tahoma"), 8); // (260624Ch) 旧: FontFamily が未破棄
-        using var fontFamily = new FontFamily("tahoma"); // (260624Ch)
-        using Font strFont = new(fontFamily, 8); // (260624Ch)
+        var strFont = tahoma8; //260712Cl 生成/破棄を廃し static キャッシュを参照
         for (int i = (int)(LowerX / AngleGradiation) + 1; i < UpperX / AngleGradiation; i++)
         {
             float x = ConvToPicBoxCoord(i * AngleGradiation, 0).X;
@@ -2347,7 +2353,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         PointD pt = ConvToRealCoord(e.X, e.Y);
 
         #region 横軸と縦軸の単位の設定
-        labelTwoTheta.Text = AxisMode switch
+        var prefix = AxisMode switch
         {
             HorizontalAxis.Angle => "2θ: ",
             HorizontalAxis.d => "d: ",
@@ -2356,10 +2362,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
             HorizontalAxis.WaveNumber => "q: ",
             _ => ""
         };
-        labelTwoTheta.Text += pt.X < 10000 ? pt.X.ToString("g6") : pt.X.ToString("#,0");
-
-
-        labelTwoTheta.Text += AxisMode switch
+        var unit = AxisMode switch
         {
             HorizontalAxis.Angle => " " + AxisProperty.TwoThetaUnitText,
             HorizontalAxis.d => " " + AxisProperty.DspacingUnitText,
@@ -2368,6 +2371,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
             HorizontalAxis.WaveNumber => " " + AxisProperty.WaveNumberUnitText,
             _ => ""
         };
+        labelTwoTheta.Text = prefix + (pt.X < 10000 ? pt.X.ToString("g6") : pt.X.ToString("#,0")) + unit; //260712Cl 1回代入に集約
         #endregion
 
         var d = HorizontalAxisConverter.ConvertToD(pt.X, HorizontalAxisProperty) * 10;
@@ -2908,7 +2912,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         }
 
         formDataConverter.textBox.Text = "";
-        var ext = Path.GetExtension(fileName).ToLower().Remove(0, 1);
+        var ext = Path.GetExtension(fileName).ToLower()[1..]; //260712Cl 範囲演算子
 
         var fileTypeNum = ext switch
         {
@@ -2961,7 +2965,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                 {
                     var nxs = new HDF(fileName);
 
-                    detectorNum = nxs.Datasets.Where(e => e.Path.Contains("/histogram")).Count();
+                    detectorNum = nxs.Datasets.Count(e => e.Path.Contains("/histogram")); //260712Cl Where().Count() → Count(述語)
                     //   nxs.Move("/entry/instrument/xspress3");
                     //  detectorNum = nxs.GetGroups().Length;
                 }
@@ -3091,42 +3095,44 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                 formDataConverter.SetProperty(FileProperties[(int)FileType.XBM]);
 
                 using var br = new BinaryReader(new FileStream(fileName, FileMode.Open, FileAccess.Read));
-                var getString = new Func<int, int, string>((position, count) =>
+                // 260712Cl 記法近代化: new Func<...>(ラムダ) → 自然型ラムダ (getString/getDouble/getInt16)
+                var getString = (int position, int count) =>
                 {
                     char[] temp = new char[count];
                     br.BaseStream.Position = position;
                     br.Read(temp, 0, temp.Length);
                     return new string(temp).TrimEnd();
-                });
+                };
 
-                var getDouble = new Func<int, double>((position) =>
+                var getDouble = (int position) =>
                 {
                     br.BaseStream.Position = position;
                     return br.ReadDouble();
-                });
+                };
 
-                var getInt16 = new Func<int, short>((position) =>
+                var getInt16 = (int position) =>
                 {
                     br.BaseStream.Position = position;
                     return br.ReadInt16();
-                });
+                };
 
-                diffProf.Comment = "Sample name: " + getString(0x4, 64);
-                diffProf.Comment += "\r\nProfile number: " + getString(0x44, 64);
-                diffProf.Comment += "\r\nDate,Time,Span: " + getString(0x84, 8) + ", " + getString(0x8c, 6) + ", " + getString(0x92, 6);
-                diffProf.Comment += "\r\nOperator name: " + getString(0x98, 30);
-                diffProf.Comment += "\r\nComment: " + getString(0xB6, 100);
-                diffProf.Comment += "\r\nEGC1,2,3: " + getDouble(0x59A) + ", " + getDouble(0x5A2) + ", " + getDouble(0x5AA);
-                diffProf.Comment += "\r\n2Theta(deg): " + getDouble(0x05B2);
-                diffProf.Comment += "\r\nLive/Real time (sec): " + getDouble(0x05F4) + "/" + getDouble(0x05EC);
-                diffProf.Comment += "\r\nDead time (%): " + getDouble(0x0686);
-                diffProf.Comment += "\r\nTemperature (degC): " + getDouble(0x05D2);
-                diffProf.Comment += "\r\nRing current (mA): " + getDouble(0x05C2) * 10;
-                diffProf.Comment += "\r\nCounting rate: " + getDouble(0x05E2);
-                diffProf.Comment += "\r\nPress conditions X:NA, Y:NA, Z:NA, Phi(deg): " + getDouble(0x0616);
-                diffProf.Comment += "\r\nIncident slit conditions (mm) V: " + getDouble(0x068E) + ", H: " + getDouble(0x0696);
-                diffProf.Comment += "\r\nReceiving slit conditions (mm) V: " + getDouble(0x06B6) + ", H: " + getDouble(0x06BE) + ", Collimator:NA";
-                diffProf.Comment += "\r\nHeating conditions  V(V): " + getDouble(0x05BA) + ", C(A): " + getDouble(0x06E6) + ", P(W): " + getDouble(0x066E) + ", R(OHM): " + getDouble(0x0676);
+                // 260712Cl 記法近代化: '+' 連結チェーン → 文字列補間
+                diffProf.Comment = $"Sample name: {getString(0x4, 64)}";
+                diffProf.Comment += $"\r\nProfile number: {getString(0x44, 64)}";
+                diffProf.Comment += $"\r\nDate,Time,Span: {getString(0x84, 8)}, {getString(0x8c, 6)}, {getString(0x92, 6)}";
+                diffProf.Comment += $"\r\nOperator name: {getString(0x98, 30)}";
+                diffProf.Comment += $"\r\nComment: {getString(0xB6, 100)}";
+                diffProf.Comment += $"\r\nEGC1,2,3: {getDouble(0x59A)}, {getDouble(0x5A2)}, {getDouble(0x5AA)}";
+                diffProf.Comment += $"\r\n2Theta(deg): {getDouble(0x05B2)}";
+                diffProf.Comment += $"\r\nLive/Real time (sec): {getDouble(0x05F4)}/{getDouble(0x05EC)}";
+                diffProf.Comment += $"\r\nDead time (%): {getDouble(0x0686)}";
+                diffProf.Comment += $"\r\nTemperature (degC): {getDouble(0x05D2)}";
+                diffProf.Comment += $"\r\nRing current (mA): {getDouble(0x05C2) * 10}";
+                diffProf.Comment += $"\r\nCounting rate: {getDouble(0x05E2)}";
+                diffProf.Comment += $"\r\nPress conditions X:NA, Y:NA, Z:NA, Phi(deg): {getDouble(0x0616)}";
+                diffProf.Comment += $"\r\nIncident slit conditions (mm) V: {getDouble(0x068E)}, H: {getDouble(0x0696)}";
+                diffProf.Comment += $"\r\nReceiving slit conditions (mm) V: {getDouble(0x06B6)}, H: {getDouble(0x06BE)}, Collimator:NA";
+                diffProf.Comment += $"\r\nHeating conditions  V(V): {getDouble(0x05BA)}, C(A): {getDouble(0x06E6)}, P(W): {getDouble(0x066E)}, R(OHM): {getDouble(0x0676)}";
 
                 formDataConverter.TakeoffAngleText = getDouble(0x05B2).ToString();
                 formDataConverter.ExposureTime = getDouble(0x05F4);
@@ -3394,7 +3400,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
 
             diffProf.ExposureTime =  formDataConverter.ExposureTime;
 
-            diffProf.Name = fileName.Remove(0, fileName.LastIndexOf('\\') + 1);
+            diffProf.Name = Path.GetFileName(fileName); //260712Cl 手書き抽出 → Path.GetFileName
 
             //線源が白色X線で、単位がkevの場合、eVに変換
             if (formDataConverter.WaveSource == Crystallography.WaveSource.Xray
@@ -3542,10 +3548,9 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
 
     public Color generateRandomColor()
     {
-        var r = new Random();
-        var max = 192 + r.Next(64);
-        var mid1 = r.Next(128);
-        var mid2 = r.Next(128);
+        var max = 192 + Random.Shared.Next(64); //260712Cl new Random() → Random.Shared
+        var mid1 = Random.Shared.Next(128);
+        var mid2 = Random.Shared.Next(128);
         if (dataSet.DataTableProfile.Items.Count is 0) //260317Cl == 0 → is 0 //直前のプロファイルがない時はR>G>Bの色を返す
             return Color.FromArgb(max, mid1, mid2);
         else//直前のプロファイルがある時はその色となるべく違う色を返す  
@@ -4217,8 +4222,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                         value[j] = value[j][..11];
                     if (value[j].EndsWith("."))
                         value[j] = string.Concat(" ", y.AsSpan(0, 10));
-                    while (value[j].Length < 11)
-                        value[j] = " " + value[j];
+                    value[j] = value[j].PadLeft(11); //260712Cl while 前置 → PadLeft
                 }
                 writer.WriteLine($" {value[0]} {value[1]} {value[2]}");
             }
@@ -4234,16 +4238,16 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
     /// </summary>
     public void horizontalAxisUserControl_AxisPropertyChanged()
     {
-        if (AxisMode == HorizontalAxis.Angle)
-            labelX.Text = "2θ ("+ AxisProperty.TwoThetaUnitText + "): ";
-        else if (AxisMode == HorizontalAxis.d)
-            labelX.Text = "d (" +AxisProperty.DspacingUnitText +  "): ";
-        else if (AxisMode == HorizontalAxis.WaveNumber)
-            labelX.Text = "q (" + AxisProperty.WaveNumberUnitText +  "):";
-        else if (AxisMode == HorizontalAxis.EnergyXray || AxisMode == HorizontalAxis.EnergyElectron || AxisMode == HorizontalAxis.EnergyNeutron)
-            labelX.Text = "Energy (" + AxisProperty.EnegyUnitText +  "): ";
-        else if (AxisMode == HorizontalAxis.NeutronTOF)
-            labelX.Text = "TOF (" +AxisProperty.TofTimeUnitText + "): ";
+        // 260712Cl 記法近代化: if/else チェーン → switch 式 + 文字列補間 (該当なしは Text 不変)
+        labelX.Text = AxisMode switch
+        {
+            HorizontalAxis.Angle => $"2θ ({AxisProperty.TwoThetaUnitText}): ",
+            HorizontalAxis.d => $"d ({AxisProperty.DspacingUnitText}): ",
+            HorizontalAxis.WaveNumber => $"q ({AxisProperty.WaveNumberUnitText}):",
+            HorizontalAxis.EnergyXray or HorizontalAxis.EnergyElectron or HorizontalAxis.EnergyNeutron => $"Energy ({AxisProperty.EnegyUnitText}): ",
+            HorizontalAxis.NeutronTOF => $"TOF ({AxisProperty.TofTimeUnitText}): ",
+            _ => labelX.Text
+        };
 
         if (skipAxisPropertyChangedEvent) return;
 
@@ -4288,18 +4292,16 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
     }
     private void numericUpDownIncreasingPixels_ValueChanged(object sender, EventArgs e)
     {
-        if (numericUpDownIncreasingPixels.Value == -1)
-            numeriBoxIncreasingPixels.Value = 0.5;
-        else if (numericUpDownIncreasingPixels.Value == -2)
-            numeriBoxIncreasingPixels.Value = 0.1;
-        else if (numericUpDownIncreasingPixels.Value == -3)
-            numeriBoxIncreasingPixels.Value = 0.05;
-        else if (numericUpDownIncreasingPixels.Value == -4)
-            numeriBoxIncreasingPixels.Value = 0.01;
-        else if (numericUpDownIncreasingPixels.Value == -5)
-            numeriBoxIncreasingPixels.Value = 0;
-        else
-            numeriBoxIncreasingPixels.Value = Math.Pow(2, (double)numericUpDownIncreasingPixels.Value);
+        // 260712Cl 記法近代化: if/else チェーン → switch 式
+        numeriBoxIncreasingPixels.Value = numericUpDownIncreasingPixels.Value switch
+        {
+            -1m => 0.5,
+            -2m => 0.1,
+            -3m => 0.05,
+            -4m => 0.01,
+            -5m => 0,
+            _ => Math.Pow(2, (double)numericUpDownIncreasingPixels.Value)
+        };
 
         if (numeriBoxIncreasingPixels.Value > float.MaxValue)
             numeriBoxIncreasingPixels.Value = numeriBoxIncreasingPixels.Value;
@@ -4348,8 +4350,8 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                 graphControlFrequency.VerticalLines = [new PointD(0, double.NaN), new PointD((double)frequencyProfile.Pt[^1].X, double.NaN)];
                 graphControlFrequency.Draw();
                 uint max = uint.MinValue;
-                foreach (uint u in dif.ImageArray.Select(v => (uint)v))
-                    max = Math.Max(u, max);
+                foreach (double v in dif.ImageArray) //260712Cl Select デリゲート除去 ((uint)v 変換は不変)
+                    max = Math.Max((uint)v, max);
                 numericUpDownMaxInt.Maximum = (decimal)max;
                 numericUpDownMinInt.Maximum = (decimal)max - 1;
                 numericUpDownMaxInt.Minimum = 0;

--- a/PDIndexer/FormMain.cs
+++ b/PDIndexer/FormMain.cs
@@ -845,7 +845,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         if (!File.Exists(UserAppDataPath + "default.xml") || new FileInfo(UserAppDataPath + "default.xml").Length < 200)
             File.Copy(appPath + "default.xml", UserAppDataPath + "default.xml", true);
 
-        if (!File.Exists(UserAppDataPath + "PDIndexerSetup.msi"))
+        if (File.Exists(UserAppDataPath + "PDIndexerSetup.msi")) //260712Cl バグ修正: 旧 !File.Exists (条件反転で「存在しない時だけ削除」=デッドコード。残留インストーラが削除されなかった)
             File.Delete(UserAppDataPath + "PDIndexerSetup.msi");
 
         //StdDbをコピー
@@ -1456,8 +1456,8 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                     {
                         int width = bmp.Width;
                         int height = bmp.Height;
-                        byte* p = (byte*)(void*)bmpData.Scan0;
-                        int nResidual = bmpData.Stride - bmp.Width * 3;
+                        int stride = bmpData.Stride; //260712Cl 並列化: 行ごとに base ポインタを再計算するため stride を保持 (旧 nResidual は各行 base 復元で不要)
+                        IntPtr scan0 = bmpData.Scan0; //260712Cl ポインタ変数はラムダにキャプチャ不可のため IntPtr で受け、各行内で byte* に復元
 
                         double endX = dif.Profile.Pt[^1].X;
                         double startX = dif.Profile.Pt[0].X;
@@ -1465,18 +1465,31 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                         double maxInt = (double)numericUpDownMaxInt.Value;
                         double minInt = (double)numericUpDownMinInt.Value;
 
-                        for (int h = 0; h < height; h++)
+                        // 260712Cl 安全な並列化: ピクセル二重ループは行 h ごとに出力メモリ領域(bitmap の1行)が完全に独立。
+                        //   x は列 w のみに依存するので列マップを1回だけ事前計算し、UI 値(LowerX/UpperX)を並列前にスナップショットして、
+                        //   行ループを Parallel.For 化する。ラムダ内に共有可変状態への書き込みも UI コントロールアクセスも無い。数値演算(除算/キャスト順)は原式のまま。
+                        double lowerX = LowerX, upperX = UpperX; //UI(NumericBox)値を並列前にスナップショット
+                        int imageWidth = dif.ImageWidth, imageHeight = dif.ImageHeight;
+                        double[] imageArray = dif.ImageArray;
+                        var xMap = new int[width];
+                        for (int w = 0; w < width; w++)
                         {
-                            int y = (int)((double)dif.ImageHeight * (double)h / (double)height);
+                            double realX = lowerX + (double)w / (double)width * (upperX - lowerX);
+                            xMap[w] = (int)(imageWidth * (realX - startX) / (endX - startX) + 0.5);
+                        }
+
+                        Parallel.For(0, height, h =>
+                        {
+                            int y = (int)((double)imageHeight * (double)h / (double)height);
+                            int yOffset = y * imageWidth;
+                            byte* p = (byte*)(void*)scan0 + (long)h * stride;
                             for (int w = 0; w < width; w++)
                             {
-
-                                double realX = LowerX + (double)w / (double)width * (UpperX - LowerX);
-                                int x = (int)(dif.ImageWidth * (realX - startX) / (endX - startX) + 0.5);
-                                if (x >= 0 && x < dif.ImageWidth)
+                                int x = xMap[w];
+                                if (x >= 0 && x < imageWidth)
                                 {
                                     int index =
-                                    (int)((dif.ImageArray[x + y * dif.ImageWidth] - minInt) / (maxInt - minInt) * 65535 + 0.5);
+                                    (int)((imageArray[x + yOffset] - minInt) / (maxInt - minInt) * 65535 + 0.5);
                                     if (index > 65535) index = 65535;
                                     if (index < 0) index = 0;
                                     if (negative) index = 65535 - index;
@@ -1485,8 +1498,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                                 }
                                 p += 3;
                             }
-                            p += nResidual;
-                        }
+                        });
                     }
                     finally { bmp.UnlockBits(bmpData); } // (260624Ch)
                     gMain.DrawImage(bmp, OriginPos.X, 0);
@@ -4280,7 +4292,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         radioButtonSingleProfileMode.Checked = !radioButtonMultiProfileMode.Checked;
 
         if (numeriBoxIncreasingPixels.Value > float.MaxValue)
-            numeriBoxIncreasingPixels.Value = numeriBoxIncreasingPixels.Value;
+            numeriBoxIncreasingPixels.Value = float.MaxValue; //260712Cl バグ修正: 旧 =自分自身(no-op)。(float)キャスト(下)でInfinityになるのを防ぐ意図のクランプ
 
         IntervalOfProfiles = (float)numeriBoxIncreasingPixels.Value;
         //checkedListBoxProfiles.Enabled = radioButtonMultiProfileMode.Checked;
@@ -4304,7 +4316,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
         };
 
         if (numeriBoxIncreasingPixels.Value > float.MaxValue)
-            numeriBoxIncreasingPixels.Value = numeriBoxIncreasingPixels.Value;
+            numeriBoxIncreasingPixels.Value = float.MaxValue; //260712Cl バグ修正: 旧 =自分自身(no-op)。(float)キャスト(下)でInfinityになるのを防ぐ意図のクランプ
         radioButtonMultiProfileMode_CheckChanged(new object(), new EventArgs());
     }
 
@@ -4787,7 +4799,7 @@ public partial class FormMain : FormBase //260604Cl Form→FormBase (F1ヘルプ
                     sw.Write(str);
                 //sw.Close(); // (260624Ch) using に移行
                 readProfile("clipbord.txt");
-                File.Delete("clipboard.txt");
+                File.Delete("clipbord.txt"); //260712Cl バグ修正: 旧 "clipboard.txt" (綴り不一致で実ファイル clipbord.txt が削除されず残留)
             }
         }
     }

--- a/PDIndexer/FormProfileSetting.cs
+++ b/PDIndexer/FormProfileSetting.cs
@@ -369,7 +369,7 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
             checkBoxSmoothing.Checked = flowLayoutPanelSmoothing.Visible = dp.DoesSmoothing;
             numericBoxSmoothingSavitzkyAndGolayM.Value = dp.SazitkyGorayM;
             numericBoxSmoothingSavitzkyAndGolayN.Value = dp.SazitkyGorayN;
-            checkBoxSmoothing.Checked = flowLayoutPanelSmoothing.Visible = dp.DoesSmoothing;
+            //260712Cl 重複行削除: 上の checkBoxSmoothing.Checked = flowLayoutPanelSmoothing.Visible = dp.DoesSmoothing; と同一文の重複だった
 
             checkBoxRemoveKalpha2.Checked = dp.DoesRemoveKalpha2;
 
@@ -734,9 +734,10 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
     }
     public void SetMaskRange(int[] index, double x)
     {
-        skipEvent = true;
+        //260712Cl バグ修正: 旧は先頭で skipEvent=true にしていたため、下の2ガードで早期returnすると skipEvent=true のまま残り、以後すべてのプロファイル更新イベントが恒久無効化されていた。ガードの後で立てる。
         if (index == null || index.Length != 2) return;
         if (bindingSourceProfile.Position < 0) return;
+        skipEvent = true;
         DiffractionProfile2 dp = (DiffractionProfile2)((DataRowView)bindingSourceProfile.Current).Row[1];
         if (index[0] >= 0 && index[0] < dp.maskingRanges.Count && index[1] >= 0 && index[1] < 2)
         {

--- a/PDIndexer/FormProfileSetting.cs
+++ b/PDIndexer/FormProfileSetting.cs
@@ -62,7 +62,7 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
             else if (n - 1 >= 0 && n - 1 < dataSetProfile.DataTableProfile.Rows.Count)
                 bindingSourceProfile.Position = n - 1;
             skipEvent = false;
-            bindingSource_CurrentChanged(new object(), new EventArgs());
+            bindingSource_CurrentChanged(this, EventArgs.Empty); //260712Cl new object()/new EventArgs() → this/EventArgs.Empty
             formMain.SetDrawRangeLimit();
             formMain.Draw();
         }
@@ -92,17 +92,18 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
         if (bindingSourceProfile.Position >= 0)
         {
             var dp = (DiffractionProfile2)((DataRowView)bindingSourceProfile.Current).Row[1];
-            string unit = "";
-            switch (dp.DstProperty.AxisMode)
+            // 260712Cl 記法近代化: switch文 → switch式
+            var unit = dp.DstProperty.AxisMode switch
             {
-                case HorizontalAxis.Angle: unit = "°"; break;
-                case HorizontalAxis.d: unit = "Å"; break;
-                case HorizontalAxis.EnergyXray: unit = "eV"; break;
-                case HorizontalAxis.NeutronTOF: unit = "ms"; break;
-            }
+                HorizontalAxis.Angle => "°",
+                HorizontalAxis.d => "Å",
+                HorizontalAxis.EnergyXray => "eV",
+                HorizontalAxis.NeutronTOF => "ms",
+                _ => ""
+            };
 
-            labelLowPath.Text = "= " + (1 / (double)numericBoxLowPass.Value).ToString("f4") + " " + unit;
-            labelHighPass.Text = "= " + (1 / (double)numericBoxHighPass.Value).ToString("f4") + " " + unit;
+            labelLowPath.Text = $"= {1 / numericBoxLowPass.Value:f4} {unit}"; //260712Cl 文字列連結+冗長(double)キャスト → 補間
+            labelHighPass.Text = $"= {1 / numericBoxHighPass.Value:f4} {unit}"; //260712Cl 同上
         }
 
         SetCurrentProfile();
@@ -465,7 +466,7 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
             var dp = (DiffractionProfile2)((DataRowView)bindingSourceProfile.Current).Row[1];
             dp.ColorARGB = colorControlLineColor.Color.ToArgb();
 
-            var g = Graphics.FromImage((Bitmap)dataSetProfile.DataTableProfile.Rows[bindingSourceProfile.Position][2]);
+            using var g = Graphics.FromImage((Bitmap)dataSetProfile.DataTableProfile.Rows[bindingSourceProfile.Position][2]); //260712Cl using宣言化 (Graphicsリーク修正)
             g.Clear(colorControlLineColor.Color);
             dataGridViewProfile.Refresh();
             formMain.dataGridViewProfiles.Refresh();
@@ -546,10 +547,8 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
 
     public void buttonCalculate_Click(object sender, EventArgs e)
     {
-        var bmp = new Bitmap(18, 18);
-        var g = Graphics.FromImage(bmp);
+        //260712Cl 未使用のGDIオブジェクト生成(bmp/g)を削除: 以降未参照かつ未Disposeでリークしていた (行アイコンはFormMain.AddProfileToCheckedListBoxが別途生成)
         var c = formMain.generateRandomColor();
-        g.Clear(c);
 
         var p = new Profile();
 
@@ -567,6 +566,7 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
                     baseIndex = i;
                 }
             }
+            p.Pt.Capacity = p.Err.Capacity = dp[baseIndex].Profile.Pt.Count; //260712Cl 初期容量指定 (数万点のList再割当てを抑制)
             for (int j = 0; j < dp[baseIndex].Profile.Pt.Count; j++)
             {
                 p.Pt.Add(new PointD(dp[baseIndex].Profile.Pt[j].X, 0));
@@ -600,9 +600,10 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
             && listBoxTwoProfiles1.SelectedIndex >= 0 && listBoxTwoProfiles2.SelectedIndex >= 0
             && listBoxTwoProfiles1.SelectedIndex != listBoxTwoProfiles2.SelectedIndex)
         {
-            var dp = new DiffractionProfile2[]{
+            // 260712Cl 記法近代化: 配列初期化子 → コレクション式
+            DiffractionProfile2[] dp = [
                 (DiffractionProfile2)dataSetProfile.DataTableProfile.Rows[listBoxTwoProfiles1.SelectedIndex][1],
-                (DiffractionProfile2)dataSetProfile.DataTableProfile.Rows[listBoxTwoProfiles2.SelectedIndex][1]};
+                (DiffractionProfile2)dataSetProfile.DataTableProfile.Rows[listBoxTwoProfiles2.SelectedIndex][1]];
 
             for (int j = 0; j < dp[0].Profile.Pt.Count; j++)
             {
@@ -700,12 +701,9 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
 
         formMain.AddProfileToCheckedListBox(output, true, true);
 
-        try
-        {
-            int n = Convert.ToInt32(textBoxOutputFilename.Text[^2..]);
-            textBoxOutputFilename.Text = $"{textBoxOutputFilename.Text[..^2]}{n + 1:00}";
-        }
-        catch { }
+        // 260712Cl 記法近代化: try/catch+Convert.ToInt32 → int.TryParse (例外を制御フローに使わない)
+        if (textBoxOutputFilename.Text.Length >= 2 && int.TryParse(textBoxOutputFilename.Text[^2..], out var seqNo)) //260712Cl 旧: out var n (同メソッド内の誤差計算ループの n と衝突するため改名)
+            textBoxOutputFilename.Text = $"{textBoxOutputFilename.Text[..^2]}{seqNo + 1:00}";
     }
 
     #region マスク関連
@@ -821,7 +819,7 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
 
     private void toolStripMenuItemReadMaskingRange_Click(object sender, EventArgs e)
     {
-        var dlg = new OpenFileDialog { Filter = "*.mas|*.mas" };
+        using var dlg = new OpenFileDialog { Filter = "*.mas|*.mas" }; //260712Cl using宣言化 (OpenFileDialog解放)
         if (dlg.ShowDialog() == System.Windows.Forms.DialogResult.OK)
             readMaskingRanges(dlg.FileName);
     }
@@ -860,7 +858,7 @@ public partial class FormProfileSetting : FormBase //260604Cl Form→FormBase (F
         string[] fileName = (string[])e.Data.GetData(DataFormats.FileDrop, false);
         if (fileName.Length == 1)
         {
-            if (fileName[0].ToLower().EndsWith(".mas"))
+            if (fileName[0].EndsWith(".mas", StringComparison.OrdinalIgnoreCase)) //260712Cl ToLower().EndsWith → OrdinalIgnoreCase比較
                 readMaskingRanges(fileName[0]);
         }
     }

--- a/PDIndexer/FormSequentialAnalysis.cs
+++ b/PDIndexer/FormSequentialAnalysis.cs
@@ -12,7 +12,7 @@ using System.Windows.Forms;
 using Crystallography;
 using IronPython.Runtime.Operations;
 using MathNet.Numerics.LinearAlgebra.Double;
-using static IronPython.Modules._ast;
+//using static IronPython.Modules._ast; //260712Cl 未使用のため削除
 #endregion
 
 namespace PDIndexer;
@@ -111,7 +111,7 @@ public partial class FormSequentialAnalysis : FormBase //260604Cl Form→FormBas
         else
         {
             textBoxPressure.Text = stressMode ? "Degree" : "Profile Name";
-            foreach (var researcher in eos().Select(e => e.Researcher))
+            foreach (var (researcher, _) in eos()) //260712Cl Select→タプル分解
                 textBoxPressure.AppendText("\t" + researcher);
             textBoxPressure.AppendText("\r\n");
 
@@ -185,7 +185,7 @@ public partial class FormSequentialAnalysis : FormBase //260604Cl Form→FormBas
             var angle = 0.0;
             if (stressMode)
             {
-                profileName = profileName.Split('-')[^1];
+                profileName = profileName[(profileName.LastIndexOf('-') + 1)..]; //260712Cl Split('-')[^1]→範囲演算子
                 if (!double.TryParse(profileName, out angle))
                     return;
                 angle = angle / 180 * Math.PI;
@@ -213,10 +213,10 @@ public partial class FormSequentialAnalysis : FormBase //260604Cl Form→FormBas
                         results[m].Add(new PointD(angle, formMain.WaveLength / 2 / Math.Sin(p.peakFunction.X / 180 * Math.PI / 2)));
                     m++;
                 }
-                textBox2theta.AppendText($"{sb2theta}\r\n");
-                textBoxDspacing.AppendText($"{sbDspacing}\r\n");
-                textBoxIntensity.AppendText($"{sbIntensity}\r\n");
-                textBoxFWHM.AppendText($"{sbFWHM}\r\n");
+                textBox2theta.AppendText(sb2theta.Append("\r\n").ToString()); //260712Cl ToString+連結の二重確保を1回に
+                textBoxDspacing.AppendText(sbDspacing.Append("\r\n").ToString());
+                textBoxIntensity.AppendText(sbIntensity.Append("\r\n").ToString());
+                textBoxFWHM.AppendText(sbFWHM.Append("\r\n").ToString());
 
                 textBoxCellConstants.AppendText($"\t{crystal.Volume * 1000:f8}\t{crystal.Volume_err * 1000:f8}" +
                     $"\t{crystal.A * 10:f10}\t{crystal.A_err * 10:f10}" +
@@ -229,7 +229,7 @@ public partial class FormSequentialAnalysis : FormBase //260604Cl Form→FormBas
 
                 if (eos != null)
                 {
-                    foreach (var pressure in eos().Select(e => e.Pressure))
+                    foreach (var (_, pressure) in eos()) //260712Cl Select→タプル分解
                         textBoxPressure.AppendText($"\t{pressure:f8}");
                     textBoxPressure.AppendText("\r\n");
                 }
@@ -242,10 +242,11 @@ public partial class FormSequentialAnalysis : FormBase //260604Cl Form→FormBas
                 var nan = double.NaN.ToString();
                 foreach (var p in crystal.Plane.Where(e => e.IsFittingChecked))
                     sb.Append($"\t{nan}");
-                textBox2theta.AppendText($"{sb}\r\n");
-                textBoxDspacing.AppendText($"{sb}\r\n");
-                textBoxIntensity.AppendText($"{sb}\r\n");
-                textBoxFWHM.AppendText($"{sb}\r\n");
+                var row = sb.Append("\r\n").ToString(); //260712Cl 共有sbのToString×4を1回に
+                textBox2theta.AppendText(row);
+                textBoxDspacing.AppendText(row);
+                textBoxIntensity.AppendText(row);
+                textBoxFWHM.AppendText(row);
                 textBoxCellConstants.AppendText($"\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\t{nan}\r\n");
                 textBoxPressure.AppendText($"\t{nan}\r\n");
             }
@@ -309,7 +310,7 @@ public partial class FormSequentialAnalysis : FormBase //260604Cl Form→FormBas
 
         if (!Path.Exists(textBoxDirectory.Text))
         {
-            buttonSetDirectory_Click(new object(), new EventArgs());
+            buttonSetDirectory_Click(this, EventArgs.Empty); //260712Cl new object()/new EventArgs()→this/Empty
             if (!Path.Exists(textBoxDirectory.Text))
                 return;
         }
@@ -319,14 +320,15 @@ public partial class FormSequentialAnalysis : FormBase //260604Cl Form→FormBas
         for (int i = 0; i < names.Length; i++)
             names[i] = formMain.dataSet.DataTableProfile.Rows[i][1].ToString().Replace(" ", "");
         var name = "";
-        for (int i = 0; i < names.Min(n => n.Length); i++)
+        var minLength = names.Min(n => n.Length); //260712Cl ループ不変のためホイスト
+        for (int i = 0; i < minLength; i++)
         {
             name += names[0][i];
-            if (names.Any(n => !n.startswith(name)))
+            if (names.Any(n => !n.StartsWith(name, StringComparison.Ordinal))) //260712Cl IronPython拡張→BCL
                 break;
         }
         name = name[..^1];
-        if (name.endswith("-") || name.endswith("#"))
+        if (name.EndsWith('-') || name.EndsWith('#')) //260712Cl IronPython拡張→BCL
             name = name[..^1];
 
         static void save(string filename, string contents)
@@ -339,19 +341,19 @@ public partial class FormSequentialAnalysis : FormBase //260604Cl Form→FormBas
         }
 
         if (checkBoxAutoSaveCell.Checked)
-            save(path + name + "_cell.csv", textBoxCellConstants.Text.Replace("\t", ","));
+            save(path + name + "_cell.csv", textBoxCellConstants.Text.Replace('\t', ',')); //260712Cl "\t"→'\t' char置換 (7箇所)
         if (checkBoxAutoSaveD.Checked)
-            save(path + name + "_d.csv", textBoxDspacing.Text.Replace("\t", ","));
+            save(path + name + "_d.csv", textBoxDspacing.Text.Replace('\t', ','));
         if (checkBoxAutoSaveFWHM.Checked)
-            save(path + name + "_fwhm.csv", textBoxFWHM.Text.Replace("\t", ","));
+            save(path + name + "_fwhm.csv", textBoxFWHM.Text.Replace('\t', ','));
         if (checkBoxAutoSaveInt.Checked)
-            save(path + name + "_intensity.csv", textBoxIntensity.Text.Replace("\t", ","));
+            save(path + name + "_intensity.csv", textBoxIntensity.Text.Replace('\t', ','));
         if (checkBoxAutoSavePressure.Checked)
-            save(path + name + "_pressure.csv", textBoxPressure.Text.Replace("\t", ","));
+            save(path + name + "_pressure.csv", textBoxPressure.Text.Replace('\t', ','));
         if (checkBoxAutoSaveSingh.Checked)
-            save(path + name + "_Singh.csv", textBoxSingh.Text.Replace("\t", ","));
+            save(path + name + "_Singh.csv", textBoxSingh.Text.Replace('\t', ','));
         if (checkBoxAutoSaveTwoTheta.Checked)
-            save(path + name + "_2theta.csv", textBox2theta.Text.Replace("\t", ","));
+            save(path + name + "_2theta.csv", textBox2theta.Text.Replace('\t', ','));
     }
 
     private void buttonSetDirectory_Click(object sender, EventArgs e)

--- a/PDIndexer/FormTwoThetaCalibration.cs
+++ b/PDIndexer/FormTwoThetaCalibration.cs
@@ -49,12 +49,12 @@ namespace PDIndexer
 
         private void numericUpDownOrder_ValueChanged(object sender, EventArgs e)
         {
-            if (numericUpDownOrder.Value == 3)
-                labelEquation.Text = string.Format(PdiText.ShiftFunction, "Δ(2θ) = a1 + a2 tan(θ) + a3 tan^2(θ) "); //260625Cl 多言語化(式は不変、"Shift function:" のみ訳)
-            else if (numericUpDownOrder.Value == 2)
-                labelEquation.Text = string.Format(PdiText.ShiftFunction, "Δ(2θ) = a1 + a2 tan(θ)"); //260625Cl 多言語化
-            else
-                labelEquation.Text = string.Format(PdiText.ShiftFunction, "Δ(2θ) = a1"); //260625Cl 多言語化
+            labelEquation.Text = string.Format(PdiText.ShiftFunction, numericUpDownOrder.Value switch //260712Cl switch式に集約 (式は不変、"Shift function:" のみ訳)
+            {
+                3 => "Δ(2θ) = a1 + a2 tan(θ) + a3 tan^2(θ) ",
+                2 => "Δ(2θ) = a1 + a2 tan(θ)",
+                _ => "Δ(2θ) = a1",
+            });
         }
 
         private void buttonCalibrate_Click(object sender, EventArgs e)
@@ -91,8 +91,9 @@ namespace PDIndexer
                 for (int i = 0; i < count; i++)
                 {
                     double tan = Math.Tan(twoThetaCalc[i] / 360.0 * Math.PI);
-                    for (int j = 0; j < order; j++)
-                        X[i, j] = Math.Pow(tan, j);
+                    double pow = 1; //260712Cl Math.Pow(tan, j) を逐次乗算に (Pow は指数を double 扱いで低速)
+                    for (int j = 0; j < order; j++, pow *= tan)
+                        X[i, j] = pow;
                     Y[i, 0] = Math.Tan(twoThetaCalc[i] - twoThetaObs[i]);
                 }
                 var inv = (X.Transpose() * X).TryInverse();

--- a/PDIndexer/FormTwoThetaCalibration.cs
+++ b/PDIndexer/FormTwoThetaCalibration.cs
@@ -82,7 +82,7 @@ namespace PDIndexer
                         twoThetaCalc.Add(p.XCalc);
                     }
                 int count = twoThetaCalc.Count;
-                if (count == 0) return;
+                if (count == 0) break; //260712Cl バグ修正: 旧 return はループ末尾の Enabled=true/ボタン文言復元(下)を飛ばしフォームが操作不能のまま残った。break で復元経路へ抜ける
 
                 int order = Math.Min((int)numericUpDownOrder.Value, count);
 

--- a/PDIndexer/GuiCapture.Diagnose.cs
+++ b/PDIndexer/GuiCapture.Diagnose.cs
@@ -25,11 +25,12 @@ internal static partial class GuiCapture
     public static void Diagnose(string outFile, double inflate = 1.0)
     {
         var culture = (ForcedUICulture ?? Thread.CurrentThread.CurrentUICulture).Name;
-        var rows = new List<string>
-        {
+        // 260712Cl 記法近代化: new List<string>{...} → collection expression
+        List<string> rows =
+        [
             // Actual/Needed は幅判定では px 幅、Label の折り返し判定では px 高さ (Reason に明記)。
             string.Join("\t", "Culture", "Form", "Control", "Type", "Text", "Font", "Actual", "Needed", "Deficit", "Severity", "Reason")
-        };
+        ];
         void Trace(string s) => Console.WriteLine($"{DateTime.Now:HH:mm:ss.fff}\t{s}");
 
         // フォーム Load/Show で投げられる例外を握りつぶす (未処理例外のモーダルダイアログでハングしないため)。
@@ -129,7 +130,7 @@ internal static partial class GuiCapture
         // 擬似ローカライズ (inflate>1) の伸長予測は「翻訳される語」にのみ意味がある。記号/単位/短いインデックスは対象外。
         if (inflate > 1.0 && !IsLikelyTranslatable(c.Text)) return;
 
-        int glyph = c is CheckBox or RadioButton ? 18 : c is ButtonBase ? 12 : c is GroupBox ? 8 : 4; // グリフ/枠の余白概算
+        int glyph = c switch { CheckBox or RadioButton => 18, ButtonBase => 12, GroupBox => 8, _ => 4 }; // グリフ/枠の余白概算 //260712Cl switch式化
 
         if (c.AutoSize)
         {

--- a/PDIndexer/GuiCapture.cs
+++ b/PDIndexer/GuiCapture.cs
@@ -69,7 +69,7 @@ internal static partial class GuiCapture //260625Cl partial 化: --diagnose を 
         var repoRoot = RepoRoot();  // 260626Cl: bin→リポルート探索を RepoRoot() に集約
         return repoRoot != null
             ? Path.Combine(repoRoot.FullName, "docs", "src", "assets", langDir)
-            : Path.Combine(Path.GetTempPath(), "pdindexer-capture-" + DateTime.Now.ToString("yyyyMMdd-HHmmss") + "-" + langDir);
+            : Path.Combine(Path.GetTempPath(), $"pdindexer-capture-{DateTime.Now:yyyyMMdd-HHmmss}-{langDir}"); //260712Cl 補間文字列化
     }
 
     /// <summary>
@@ -394,7 +394,7 @@ internal static partial class GuiCapture //260625Cl partial 化: --diagnose を 
                 }
                 else
                 {
-                    var region = control is TabPage tabPage && tabPage.Parent is TabControl tabControl ? (Control)tabControl : control;
+                    var region = control is TabPage { Parent: TabControl tabControl } ? (Control)tabControl : control; //260712Cl プロパティパターン化
                     region.Refresh();
                     Settle(form, TabSwitchSettleMs);
                     crop = CaptureScreen(new Rectangle(GetScreenLocation(region), region.Size), form, trace, $"{name}.{control.Name}", retryIfSolid: true);
@@ -467,9 +467,8 @@ internal static partial class GuiCapture //260625Cl partial 化: --diagnose を 
     /// <summary>260601Cl: フォーム内の全 ToolStripItem を列挙する (Controls 配下の ToolStrip + designer field の ContextMenuStrip 等。ドロップダウン項目も再帰)。</summary>
     private static IEnumerable<ToolStripItem> EnumerateToolStripItems(Form form)
     {
-        var toolStrips = new HashSet<ToolStrip>();
-        foreach (var toolStrip in EnumerateControls(form).OfType<ToolStrip>())
-            toolStrips.Add(toolStrip);
+        // 260712Cl 記法近代化: new + foreach + Add を ToHashSet() へ集約
+        var toolStrips = EnumerateControls(form).OfType<ToolStrip>().ToHashSet();
         for (var type = form.GetType(); type != null; type = type.BaseType)
             foreach (var field in type.GetFields(System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.DeclaredOnly))
                 if (typeof(ToolStrip).IsAssignableFrom(field.FieldType) && field.GetValue(form) is ToolStrip ownedToolStrip)

--- a/PDIndexer/GuiCapture.cs
+++ b/PDIndexer/GuiCapture.cs
@@ -282,12 +282,12 @@ internal static partial class GuiCapture //260625Cl partial 化: --diagnose を 
     private static void Settle(Form form, int ms)
     {
         try { form.Refresh(); } catch { /* Refresh 時例外は無視 */ }
-        var until = Environment.TickCount + Math.Max(ms, 0);
+        var until = Environment.TickCount64 + Math.Max(ms, 0); //260712Cl バグ修正: 旧 TickCount(Int32) は約24.9日周期のラップ境界で until が負に折り返し待機が即終了する。TickCount64 で安全に
         do
         {
             Application.DoEvents();
             System.Threading.Thread.Sleep(15);
-        } while (Environment.TickCount < until);
+        } while (Environment.TickCount64 < until);
     }
 
     private const int CaptureMaxAttempts = 5; // CopyFromScreen 失敗時の最大試行回数

--- a/PDIndexer/Macro.cs
+++ b/PDIndexer/Macro.cs
@@ -372,7 +372,7 @@ public class Macro : MacroBase
         public void ReadProfiles(string fileName = "") => Execute(() =>
         {
             if (!System.IO.File.Exists(fileName))
-                main.menuItemFileRead_Click(new object(), new EventArgs());
+                main.menuItemFileRead_Click(new object(), EventArgs.Empty); //260712Cl new EventArgs() → EventArgs.Empty
             else
                 main.readProfile(fileName);
         });
@@ -381,7 +381,7 @@ public class Macro : MacroBase
         public void SaveProfiles(string filename = "") => Execute(() =>
         {
             if (filename == "")
-                main.savePatternProfileToolStripMenuItem_Click(new object(), new EventArgs());
+                main.savePatternProfileToolStripMenuItem_Click(new object(), EventArgs.Empty); //260712Cl new EventArgs() → EventArgs.Empty
             else
                 main.SaveProfile(filename);
         });
@@ -390,7 +390,7 @@ public class Macro : MacroBase
         public void ReadCrystals(string filename = "") => Execute(() =>
         {
             if (!System.IO.File.Exists(filename))
-                main.menuItemReadCrystalData_Click(new object(), new EventArgs());
+                main.menuItemReadCrystalData_Click(new object(), EventArgs.Empty); //260712Cl new EventArgs() → EventArgs.Empty
             else
                 main.readCrystal(filename, false, true);
         });
@@ -399,7 +399,7 @@ public class Macro : MacroBase
         public void SaveCrystals(string filename = "") => Execute(() =>
         {
             if (filename == "")
-                main.menuItemSaveCrystalData_Click(new object(), new EventArgs());
+                main.menuItemSaveCrystalData_Click(new object(), EventArgs.Empty); //260712Cl new EventArgs() → EventArgs.Empty
             else
                 main.saveCrystal(filename);
         });
@@ -408,7 +408,7 @@ public class Macro : MacroBase
         public void SaveMetafile(string filename = "") => Execute(() =>
         {
             if (filename == "")
-                main.toolStripMenuItemSaveMetafile_Click(new object(), new EventArgs());
+                main.toolStripMenuItemSaveMetafile_Click(new object(), EventArgs.Empty); //260712Cl new EventArgs() → EventArgs.Empty
             else
                 main.saveMetafile(filename);
         });
@@ -529,12 +529,16 @@ public class Macro : MacroBase
         {
             var c = main.CurrentCrystal;
             if (c == null) return;
-            if (index == 0) c.A = val / 10;
-            if (index == 1) c.B = val / 10;
-            if (index == 2) c.C = val / 10;
-            if (index == 3) c.Alpha = val / 180.0 * Math.PI;
-            if (index == 4) c.Beta = val / 180.0 * Math.PI;
-            if (index == 5) c.Gamma = val / 180.0 * Math.PI;
+            // 260712Cl 記法近代化: 排他的な if チェーンを switch 文に置換
+            switch (index)
+            {
+                case 0: c.A = val / 10; break;
+                case 1: c.B = val / 10; break;
+                case 2: c.C = val / 10; break;
+                case 3: c.Alpha = val / 180.0 * Math.PI; break;
+                case 4: c.Beta = val / 180.0 * Math.PI; break;
+                case 5: c.Gamma = val / 180.0 * Math.PI; break;
+            }
 
             c.SetAxis();
             c.SetPlanes();

--- a/PDIndexer/Program.cs
+++ b/PDIndexer/Program.cs
@@ -23,7 +23,7 @@ namespace PDIndexer
             // 260625Cl 追加: --smoke (WiX 移行 Phase C / D-PDI-3)。GUI を作らず Xraylib.Enabled を参照するだけで
             //   static ctor (libxrl-11.dll ロード + self-test) を起動し、実機で xraylib が本当にロードできるか検査する。
             //   引数なしの通常起動には一切影響しない (--capture と同様、先頭引数判定のみ)。
-            if (args.Length >= 1 && args[0] == SmokeArg)
+            if (args is [SmokeArg, ..]) //260712Cl 記法近代化: list pattern
             {
                 RunSmoke(args.Length >= 2 ? args[1] : "smoke-result.txt");
                 return; // RunSmoke は Environment.Exit するため通常ここには到達しない

--- a/PDIndexer/UserControlIonicRadius.Designer.cs
+++ b/PDIndexer/UserControlIonicRadius.Designer.cs
@@ -96,8 +96,8 @@
             // 
             // UserControlIonicRadius
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(8F, 20F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
             this.AutoSize = true;
             this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.Controls.Add(this.flowLayoutPanel1);

--- a/PDIndexer/UserControlIonicRadius.cs
+++ b/PDIndexer/UserControlIonicRadius.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows.Forms;
+﻿using System; //260712Cl Math.Clamp用
+using System.Windows.Forms;
 
 namespace PDIndexer;
 
@@ -14,20 +15,14 @@ public partial class UserControlIonicRadius : UserControl
     {
         set
         {
-            if ((decimal)value * 10 > numericUpDownRadius.Maximum)
-                numericUpDownRadius.Value = numericUpDownRadius.Maximum;
-            else if ((decimal)value * 10 < numericUpDownRadius.Minimum)
-                numericUpDownRadius.Value = numericUpDownRadius.Minimum;
-            else
-                numericUpDownRadius.Value = (decimal)value * 10;
+            numericUpDownRadius.Value = Math.Clamp((decimal)value * 10, numericUpDownRadius.Minimum, numericUpDownRadius.Maximum); //260712Cl Math.Clampでクランプ
         }
         get => (double)numericUpDownRadius.Value / 10;
     }
 
     public string Element { set => labelElement.Text = value; get => labelElement.Text; }
 
-    private int atomicNumber = 0;
-    public int AtomicNumber { set => atomicNumber = value; get => atomicNumber; }
+    public int AtomicNumber { get; set; } //260712Cl 自動プロパティ化
 
 
 }

--- a/PDIndexer/Version.cs
+++ b/PDIndexer/Version.cs
@@ -311,7 +311,7 @@ static class Version
         "\r\n ver1.00 (2005/06/??) とりあえず動くものをつくる"
         ;
 
-    static public string VersionAndDate { get => History.Remove(0, 10).Remove(20); }
+    static public string VersionAndDate => History[10..30];    //260712Cl Remove(0,10).Remove(20) → range slice [10..30]
     //バージョンの値 (20241206 doubleから整数に変換)
     static public int VersionValue { get => Convert.ToInt32(VersionAndDate[3..^12].Replace(".",""), System.Globalization.CultureInfo.InvariantCulture); }
 
@@ -391,7 +391,7 @@ static class Version
         + "\r\nできるだけご要望にお応えしたいと思います。"
         ;
 
-    static public string[] HintJa = new string[]{
+    static public string[] HintJa = [    //260712Cl new string[]{} → []
 
         "キーボードショートカット\r\n    Ctrl + Shift + C : Crystal Parameter\r\n    Ctrl + Shift + P : Profile Setting\r\n    Ctrl + Shift + E : Equation of State\r\n    Ctrl + Shift + F : Fitting Diffraction",
         "Ctrl+Shift+Dキーを押すと回折線の描画モードを以下のように切り替えることができます。\r\n 非表示 -> 表示(強度計算なし) -> 表示(強度計算あり)",
@@ -405,9 +405,9 @@ static class Version
         "複数のプロファイルの保存・読み込みが可能です。(pdi形式のみ)",
         "英語のマニュアルを作成していただける方募集中です。",
 
-    };
+    ];
 
-    static public string[] HintEn = new string[]{
+    static public string[] HintEn = [    //260712Cl new string[]{} → []
 
         "Keyboard shortcut\r\n    Ctrl + Shift + C : Crystal Parameter\r\n    Ctrl + Shift + P : Profile Setting\r\n    Ctrl + Shift + E : Equation of State\r\n    Ctrl + Shift + F : Fitting Diffraction",
       //  "Ctrl+Shift+Dキーを押すと回折線の描画モードを以下のように切り替えることができます。\r\n 非表示 -> 表示(強度計算なし) -> 表示(強度計算あり)",
@@ -421,7 +421,7 @@ static class Version
       //  "複数のプロファイルの保存・読み込みが可能です。(pdi形式のみ)",
       //  "英語のマニュアルを作成していただける方募集中です。",
 
-    };
+    ];
 
 
 }

--- a/PDIndexer/Version.cs
+++ b/PDIndexer/Version.cs
@@ -311,7 +311,7 @@ static class Version
         "\r\n ver1.00 (2005/06/??) とりあえず動くものをつくる"
         ;
 
-    static public string VersionAndDate => History[10..30];    //260712Cl Remove(0,10).Remove(20) → range slice [10..30]
+    static public string VersionAndDate { get => History.Remove(0, 10).Remove(20); }
     //バージョンの値 (20241206 doubleから整数に変換)
     static public int VersionValue { get => Convert.ToInt32(VersionAndDate[3..^12].Replace(".",""), System.Globalization.CultureInfo.InvariantCulture); }
 
@@ -391,7 +391,7 @@ static class Version
         + "\r\nできるだけご要望にお応えしたいと思います。"
         ;
 
-    static public string[] HintJa = [    //260712Cl new string[]{} → []
+    static public string[] HintJa = new string[]{
 
         "キーボードショートカット\r\n    Ctrl + Shift + C : Crystal Parameter\r\n    Ctrl + Shift + P : Profile Setting\r\n    Ctrl + Shift + E : Equation of State\r\n    Ctrl + Shift + F : Fitting Diffraction",
         "Ctrl+Shift+Dキーを押すと回折線の描画モードを以下のように切り替えることができます。\r\n 非表示 -> 表示(強度計算なし) -> 表示(強度計算あり)",
@@ -405,9 +405,9 @@ static class Version
         "複数のプロファイルの保存・読み込みが可能です。(pdi形式のみ)",
         "英語のマニュアルを作成していただける方募集中です。",
 
-    ];
+    };
 
-    static public string[] HintEn = [    //260712Cl new string[]{} → []
+    static public string[] HintEn = new string[]{
 
         "Keyboard shortcut\r\n    Ctrl + Shift + C : Crystal Parameter\r\n    Ctrl + Shift + P : Profile Setting\r\n    Ctrl + Shift + E : Equation of State\r\n    Ctrl + Shift + F : Fitting Diffraction",
       //  "Ctrl+Shift+Dキーを押すと回折線の描画モードを以下のように切り替えることができます。\r\n 非表示 -> 表示(強度計算なし) -> 表示(強度計算あり)",
@@ -421,7 +421,7 @@ static class Version
       //  "複数のプロファイルの保存・読み込みが可能です。(pdi形式のみ)",
       //  "英語のマニュアルを作成していただける方募集中です。",
 
-    ];
+    };
 
 
 }


### PR DESCRIPTION
Repo-wide refactoring pass (multi-agent static analysis → adversarial verification → Codex second opinion → applied → behavior-preserving review).

## Commits
- **Submodule bump**: Crystallography 99958eb / Controls 8244ecc
- **Modernization (~185 mechanical, behavior-preserving)**: string interpolation, switch expressions, target-typed new, collection expressions, range operators, method groups; GDI object caching / `using`, hot-path allocation hoisting, redundant `ToArray`/`ToList` removal, `Items.Count` hoisted out of loops (O(n²)→O(n)). Old code not commented out, date marker `260712Cl` only. SimdLinq targets untouched.
- **Bug fixes (11, clear/behavior-restoring)**: `Process.Start` → `ProcessStartInfo{UseShellExecute=true}` (mailto/URL broken since .NET Core); CSV "Spl Pea" → `SplitPearson` (peak function corrupted on save/reload); self-assignment guard → `float.MaxValue` clamp; inverted leftover-installer delete condition; temp-file name mismatch; `skipEvent` permanent-disable on early return; 2θ calibration state restore; FormCellFinder Stop→Find race (IsBusy guard) and swallowed worker exceptions (e.Error); `Environment.TickCount` → `TickCount64`.
- **Safe parallelization**: `DrawUnrolledImage` pixel loop → per-row `Parallel.For` (UI values snapshotted, column map precomputed, pointer via IntPtr; bit-identical output).
- **GDI leak**: `FormCrystal.ChangeCrystal` disposes the old row Bitmap before replacing it.

## Not included (reported for decision)
7 science/design-sensitive bugs left unfixed (BeginInvoke atomic-position stall, dValue convergence guard, error propagation typos, 2θ regression target, GSAS validErr inversion, etc.) — they change numerical results or need design decisions.

## Release note
Version.cs is intentionally identical to master so this merge does **not** trigger the release CI. Build: 0 errors; `--smoke` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)